### PR TITLE
Update Fourier expansion framework to Sage 4.8.

### DIFF
--- a/psage/modform/fourier_expansion_framework/gradedexpansions/expansion_lazy_evaluation.py
+++ b/psage/modform/fourier_expansion_framework/gradedexpansions/expansion_lazy_evaluation.py
@@ -42,6 +42,7 @@ def LazyFourierExpansionEvaluation(parent, element, precision) :
     TESTS::
         sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
         sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
+        sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_lazy_evaluation import LazyFourierExpansionEvaluation
         sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
         sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
         sage: em = ExpansionModule(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
@@ -72,6 +73,7 @@ class DelayedEvaluation_fourier_expansion :
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_lazy_evaluation import DelayedEvaluation_fourier_expansion
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
@@ -93,6 +95,7 @@ class DelayedEvaluation_fourier_expansion :
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_lazy_evaluation import DelayedEvaluation_fourier_expansion
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))

--- a/psage/modform/fourier_expansion_framework/gradedexpansions/expansion_module.py
+++ b/psage/modform/fourier_expansion_framework/gradedexpansions/expansion_module.py
@@ -1,8 +1,8 @@
-"""
+r"""
 Module abstractly spanned by Fourier expansions. 
 
-AUTHOR :
-    -- Martin Raum (2010 - 05 - 15) Initial version
+AUTHOR:
+    - Martin Raum (2010 - 05 - 15) Initial version
 """
 
 #===============================================================================
@@ -47,7 +47,7 @@ from sage.rings.principal_ideal_domain import PrincipalIdealDomain
 from sage.rings.rational_field import QQ
 from sage.rings.ring import Ring
 from sage.structure.element import Element
-from sage.structure.sequence import Sequence
+from sage.structure.sequence import Sequence, Sequence_generic
 import itertools
 
 #===============================================================================
@@ -55,7 +55,7 @@ import itertools
 #===============================================================================
 
 def ExpansionModule(forms) :
-    """
+    r"""
     Construct a module of over the forms' base ring of rank ``len(forms)``
     with underlying expansions associated to.
     
@@ -100,7 +100,7 @@ def ExpansionModule(forms) :
         ...
         TypeError: The forms' base ring must be a commutative ring.
     """
-    if not isinstance(forms, Sequence) :
+    if not isinstance(forms, Sequence_generic) :
         forms = Sequence(forms)
         if len(forms) == 0 :
             raise ValueError( "Empty modules must be constructed with a universe." )
@@ -134,12 +134,12 @@ def ExpansionModule(forms) :
 #===============================================================================
 
 class ExpansionModule_abstract :
-    """
+    r"""
     An abstract implementation of a module with expansions associated to its basis elements.
     """
     
     def __init__(self, basis, **kwds) :
-        """
+        r"""
         INPUT:
             - ``basis`` -- A sequence of (equivariant) monoid power series.
         
@@ -147,13 +147,14 @@ class ExpansionModule_abstract :
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_abstract
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", QQ))
             sage: em = ExpansionModule_abstract(Sequence([emps.one_element(), emps.one_element()]))
         """
         self.__abstract_basis = basis
 
     def _abstract_basis(self) :
-        """
+        r"""
         Return a basis in terms of elements of the graded ambient.
         
         OUTPUT:
@@ -173,7 +174,7 @@ class ExpansionModule_abstract :
 
     @cached_method
     def precision(self) :
-        """
+        r"""
         A common precision of the expansions associated to the basis elements.
         
         OUTPUT:
@@ -203,7 +204,7 @@ class ExpansionModule_abstract :
                 return self.__abstract_basis.universe().monoid().filter_all()
     
     def _bounding_precision(self) :
-        """
+        r"""
         A common precision of the expansions associtated to the basis elements
         if it is finite or in case it is not a filter that comprises all
         nonzero coefficient of the expansion.
@@ -236,12 +237,12 @@ class ExpansionModule_abstract :
 
     @cached_method
     def _check_precision(self, precision = None, lazy_rank_check = False) :
-        """
+        r"""
         Check whether the elements of this module are uniquely determined
         by their Fourier expansions up to ``precision``. If ``precision`` is ``None``
         the precision of this module will be used.
         
-        INPUT::
+        INPUT:
             - ``precision``        -- A filter for the expansions' parent monoid or action or ``None`` (default: ``None``).
             - ``lazy_rank_check``  -- A boolean (default: ``False``); If ``True`` the involved rank checks will
                                       be done over `Q_p` (with finite precision).
@@ -308,7 +309,7 @@ class ExpansionModule_abstract :
         return basis_fe_expansion.rank() >= self.rank()
     
     def _fourier_expansion_of_element(self, e) :
-        """
+        r"""
         The Fourier expansion of an element optained via linear combinations
         of the basis' Fourier expansions.
         
@@ -336,7 +337,7 @@ class ExpansionModule_abstract :
 
     @cached_method
     def _non_zero_characters(self) :
-        """
+        r"""
         Return those characters which cannot be guaranteed to have vanishing Fourier
         expansion associated with for all basis elements of ``self``.
         
@@ -364,7 +365,7 @@ class ExpansionModule_abstract :
 
     @cached_method
     def _fourier_expansion_indices(self) :
-        """
+        r"""
         A list of Fourier indices which are considered by the Fourier expansion morphism.
         
         OUTPUT:
@@ -420,7 +421,7 @@ class ExpansionModule_abstract :
 
     @cached_method
     def fourier_expansion_homomorphism(self, precision = None) :
-        """
+        r"""
         A morphism mapping elements of the underlying module to
         a module such that each component of the image corresponds to an
         Fourier coefficient of the Fourier expansion associated with this
@@ -452,7 +453,7 @@ class ExpansionModule_abstract :
             sage: em = ExpansionModule(Sequence([hv]))
             sage: em.fourier_expansion_homomorphism()
             Free module morphism defined by the matrix
-            (not printing 1 x 9 matrix)
+            [0 0 0 1 0 0 0 0 1]
             Domain: Module of Fourier expansions in Module of equivariant monoid ...
             Codomain: Vector space of dimension 9 over Rational Field
         """
@@ -470,7 +471,7 @@ class ExpansionModule_abstract :
     
     @cached_method
     def _fourier_expansion_matrix_over_fraction_field(self) :
-        """
+        r"""
         The matrix associated with the Fourier expansion homomorphism
         such that its base ring is a field.
         
@@ -497,7 +498,7 @@ class ExpansionModule_abstract :
                   
     @cached_method
     def pivot_elements(self) :
-        """
+        r"""
         Determine a set of generators, which minimally span the image of the Fourier expansion
         homomorphism.
         
@@ -533,10 +534,10 @@ class ExpansionModule_abstract :
         if expansion_matrix.rank() == self.rank() :
             return range(self.rank())
         else :
-            return expansion_matrix.pivots()
+            return list(expansion_matrix.pivots())
                   
     def _element_to_fourier_expansion_generator(self, e) :
-        """
+        r"""
         Given a monoid power series `e` return a generator iterating over the components of
         the image of `e` under the Fourier expansion morphism.
 
@@ -581,7 +582,7 @@ class ExpansionModule_abstract :
             return (e[k][i] if k in e else 0 for (i,k) in keys)
 
     def coordinates(self, x, in_base_ring = True, force_ambigous = False) :
-        """
+        r"""
         The coordinates in ``self`` of an element either of the following:
             - An element of a submodule.
             - An expansion in the parent of the basis' expansions.
@@ -636,7 +637,7 @@ class ExpansionModule_abstract :
             [1/2]
             sage: K.<rho> = CyclotomicField(6)
             sage: em.coordinates(rho * emps.one_element(), in_base_ring = False)
-            [rho]
+            [zeta6]
             sage: h = EquivariantMonoidPowerSeries(emps, {emps.characters().one_element(): {1: 2, 2: 3}}, emps.action().filter_all())
             sage: em.coordinates(h)
             Traceback (most recent call last):
@@ -781,7 +782,7 @@ class ExpansionModule_abstract :
         raise ArithmeticError( "No coordinates for %s." % (x,) )
         
     def _sparse_module(self):
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
@@ -796,7 +797,7 @@ class ExpansionModule_abstract :
         raise NotImplementedError
 
     def _dense_module(self):
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
@@ -809,7 +810,7 @@ class ExpansionModule_abstract :
         return self
 
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
@@ -821,26 +822,26 @@ class ExpansionModule_abstract :
         return "Module of Fourier expansions in %s" % (self.__abstract_basis.universe(),)            
 
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: latex( ExpansionModule(Sequence([emps.one_element()])) )
-            Module of Fourier expansions in Ring of equivariant monoid power series over $\NN$
+            \text{Module of Fourier expansions in }\text{Ring of equivariant monoid power series over }\Bold{N}
         """
-        return "Module of Fourier expansions in %s" % (latex(self.__abstract_basis.universe()),)
+        return r"\text{Module of Fourier expansions in }%s" % (latex(self.__abstract_basis.universe()),)
 
 
 class ExpansionModule_generic ( ExpansionModule_abstract, FreeModule_generic ) :
-    """
+    r"""
     A generic module of abstract elements with Fourier expansions attached to.
     The base ring has to be an integral domain.
     """
     
     def __init__(self, basis, degree, **kwds) :
-        """
+        r"""
         INPUT:
             - ``basis``  -- A sequence of (equivariant) monoid power series.
             - ``degree`` -- An integer; The ambient's module dimension.
@@ -854,6 +855,7 @@ class ExpansionModule_generic ( ExpansionModule_abstract, FreeModule_generic ) :
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_generic, ExpansionModuleVector_generic
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_generic(Sequence([emps.one_element()]), 2)
@@ -869,7 +871,7 @@ class ExpansionModule_generic ( ExpansionModule_abstract, FreeModule_generic ) :
         FreeModule_generic.__init__(self, basis.universe().base_ring(), len(basis), degree, sparse = False)
 
     def gen(self, i) :
-        """
+        r"""
         The `i`-th generator of the module.
         
         INPUT:
@@ -881,6 +883,7 @@ class ExpansionModule_generic ( ExpansionModule_abstract, FreeModule_generic ) :
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_generic
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_generic(Sequence([emps.one_element()]), 1)
@@ -892,7 +895,7 @@ class ExpansionModule_generic ( ExpansionModule_abstract, FreeModule_generic ) :
         raise NotImplementedError
 
     def basis(self) :
-        """
+        r"""
         A basis of ``self``.
         
         OUTPUT:
@@ -901,6 +904,7 @@ class ExpansionModule_generic ( ExpansionModule_abstract, FreeModule_generic ) :
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_generic
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_generic(Sequence([emps.one_element()]), 1)
@@ -912,7 +916,7 @@ class ExpansionModule_generic ( ExpansionModule_abstract, FreeModule_generic ) :
         raise NotImplementedError
     
     def change_ring(self, R):
-        """
+        r"""
         Return the ambient expansion module over `R` with the same basis as ``self``.
         
         INPUT:
@@ -925,6 +929,7 @@ class ExpansionModule_generic ( ExpansionModule_abstract, FreeModule_generic ) :
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_generic
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_generic(Sequence([emps.one_element()]), 2)
             sage: em.change_ring(ZZ) is em
@@ -947,7 +952,7 @@ class ExpansionModule_generic ( ExpansionModule_abstract, FreeModule_generic ) :
 #===============================================================================
 
 def _fourier_expansion_kernel(self) :
-    """
+    r"""
     The kernel of the Fourier expansion morphism.
     
     OUTPUT:
@@ -982,7 +987,7 @@ def _fourier_expansion_kernel(self) :
 #===============================================================================
 
 def _span( self, gens, base_ring = None, check = True, already_echelonized = False ) :
-    """
+    r"""
     The expansion submodule spanned by ``gens``.
     
     INPUT:
@@ -1035,12 +1040,12 @@ def _span( self, gens, base_ring = None, check = True, already_echelonized = Fal
 #===============================================================================
 
 class ExpansionModule_ambient_pid ( ExpansionModule_abstract, FreeModule_ambient_pid ) :
-    """
+    r"""
     An ambient module of expansions over a principal ideal domain.
     """
     
     def __init__(self, basis, _element_class = None, **kwds) :
-        """
+        r"""
         INPUT:
             - ``basis``         -- A list or sequence of (equivariant) monoid power series.
             - ``element_class`` -- A type or ``None`` (default: ``None``); The element class
@@ -1051,6 +1056,7 @@ class ExpansionModule_ambient_pid ( ExpansionModule_abstract, FreeModule_ambient
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_ambient_pid, ExpansionModuleVector_generic
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_ambient_pid(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
             sage: em = ExpansionModule_ambient_pid(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]), _element_class = ExpansionModuleVector_generic)
@@ -1078,7 +1084,7 @@ class ExpansionModule_ambient_pid ( ExpansionModule_abstract, FreeModule_ambient
     span = _span
     
     def gen(self, i) :
-        """
+        r"""
         The `i`-th generator of the module.
         
         INPUT:
@@ -1091,6 +1097,7 @@ class ExpansionModule_ambient_pid ( ExpansionModule_abstract, FreeModule_ambient
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_ambient_pid
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_ambient_pid(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
             sage: em.gen(0)
@@ -1099,7 +1106,7 @@ class ExpansionModule_ambient_pid ( ExpansionModule_abstract, FreeModule_ambient
         return self._element_class(self, FreeModule_ambient_pid.gen(self, i))
 
     def basis(self) :
-        """
+        r"""
         A basis of ``self``.
         
         OUTPUT:
@@ -1109,6 +1116,7 @@ class ExpansionModule_ambient_pid ( ExpansionModule_abstract, FreeModule_ambient
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_ambient_pid
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_ambient_pid(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
             sage: em.basis()
@@ -1117,7 +1125,7 @@ class ExpansionModule_ambient_pid ( ExpansionModule_abstract, FreeModule_ambient
         return map(lambda b: self._element_class(self, b), FreeModule_ambient_pid.basis(self))    
         
     def change_ring(self, R):
-        """
+        r"""
         Return the ambient expansion module over `R` with the same basis as ``self``.
         
         INPUT:
@@ -1130,6 +1138,7 @@ class ExpansionModule_ambient_pid ( ExpansionModule_abstract, FreeModule_ambient
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_ambient_pid
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_ambient_pid(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
             sage: em.change_ring(ZZ) is em
@@ -1148,7 +1157,7 @@ class ExpansionModule_ambient_pid ( ExpansionModule_abstract, FreeModule_ambient
         return ExpansionModule_ambient_pid(Sequence(self._abstract_basis(), universe = R), _element_class = self._element_class)
 
     def ambient_module(self) :
-        """
+        r"""
         Return the ambient module of ``self``.
         
         OUTPUT:
@@ -1158,6 +1167,7 @@ class ExpansionModule_ambient_pid ( ExpansionModule_abstract, FreeModule_ambient
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_ambient_pid
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_ambient_pid(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
             sage: em.ambient_module() is em
@@ -1170,12 +1180,12 @@ class ExpansionModule_ambient_pid ( ExpansionModule_abstract, FreeModule_ambient
 #===============================================================================
 
 class ExpansionModule_submodule_pid ( ExpansionModule_abstract, FreeModule_submodule_pid ) :
-    """
+    r"""
     A submodule of another module of expansions over a principal ideal domain.
     """
 
     def __init__(self, ambient, gens, _element_class = None, **kwds) :
-        """
+        r"""
         INPUT:
             - ``ambient``       -- An instance of :class:~`.ExpansionModule_ambient_pid` or :class:~`.ExpansionModule_submodule_pid`.
             - ``gens``          -- A list, tuple or sequence of elements of ``ambient``.
@@ -1187,6 +1197,7 @@ class ExpansionModule_submodule_pid ( ExpansionModule_abstract, FreeModule_submo
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_ambient_pid, ExpansionModule_submodule_pid, ExpansionModuleVector_generic
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_ambient_pid(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
             sage: ems = ExpansionModule_submodule_pid(em, [em([1,0,0]), em([1,2,0])])
@@ -1213,7 +1224,7 @@ class ExpansionModule_submodule_pid ( ExpansionModule_abstract, FreeModule_submo
     span = _span
 
     def gen(self, i) :
-        """
+        r"""
         The `i`-th generator of the module.
         
         INPUT:
@@ -1226,35 +1237,38 @@ class ExpansionModule_submodule_pid ( ExpansionModule_abstract, FreeModule_submo
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_ambient_pid, ExpansionModule_submodule_pid
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_ambient_pid(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
             sage: ems = ExpansionModule_submodule_pid(em, [em([1,0,0]), em([1,2,0])])
             sage: ems.gen(0)
             (1, 0, 0)
         """
-        return self._element_class(self, FreeModule_submodule_pid.gen(self, i).list())
+        return self._element_class(self, super(ExpansionModule_submodule_pid, self).gen(i).list())
 
-    def basis(self) :
-        """
-        A basis of ``self``.
+    # TODO: The module should be hidden so that we can adopt the category framework
+    # def basis(self) :
+    #     r"""
+    #     A basis of ``self``.
         
-        OUTPUT:
-            A list of elements of ``self``.
+    #     OUTPUT:
+    #         A list of elements of ``self``.
         
-        TESTS::
-            sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
-            sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
-            sage: em = ExpansionModule_ambient_pid(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
-            sage: ems = ExpansionModule_submodule_pid(em, [em([1,0,0]), em([1,2,0])])
-            sage: ems.basis()
-            [(1, 0, 0), (0, 2, 0)]
-        """
-        return [self._element_class(self, b.list()) for b in FreeModule_submodule_pid.basis(self)]    
+    #     TESTS::
+    #         sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
+    #         sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
+    #         sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+    #         sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_ambient_pid, ExpansionModule_submodule_pid
+    #         sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+    #         sage: em = ExpansionModule_ambient_pid(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
+    #         sage: ems = ExpansionModule_submodule_pid(em, [em([1,0,0]), em([1,2,0])])
+    #         sage: ems.basis()
+    #         [(1, 0, 0), (0, 2, 0)]
+    #     """
+    #     return [self._element_class(self, b.list()) for b in super().basis()]
     
     def change_ring(self, R):
-        """
+        r"""
         Return the ambient expansion module over `R` with the same basis as ``self``.
         
         INPUT:
@@ -1266,6 +1280,7 @@ class ExpansionModule_submodule_pid ( ExpansionModule_abstract, FreeModule_submo
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule_ambient_pid, ExpansionModule_submodule_pid
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule_ambient_pid(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
             sage: ems = ExpansionModule_submodule_pid(em, [em([1,0,0]), em([1,2,0])])
@@ -1290,12 +1305,12 @@ class ExpansionModule_submodule_pid ( ExpansionModule_abstract, FreeModule_submo
 #===============================================================================
 
 class ExpansionModuleVector_generic ( FreeModuleElement_generic_dense, FourierExpansionWrapper ) :
-    """
+    r"""
     A generic implementation of an element in a module of expansions.
     """
     
     def __init__(self, parent, x, coerce = True, copy = True) :
-        """
+        r"""
         INPUT:
             - ``parent``  -- An instance of :class:~`.ExpansionModule_abstract`.
             - `x`         -- A list or tuple of integers or an element that admits coordinates
@@ -1307,6 +1322,7 @@ class ExpansionModuleVector_generic ( FreeModuleElement_generic_dense, FourierEx
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModuleVector_generic
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
             sage: ExpansionModuleVector_generic(em, [1,0,2])
@@ -1320,7 +1336,7 @@ class ExpansionModuleVector_generic ( FreeModuleElement_generic_dense, FourierEx
         FreeModuleElement_generic_dense.__init__(self, parent, x, coerce, copy)
     
     def _add_(left, right) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
@@ -1333,7 +1349,7 @@ class ExpansionModuleVector_generic ( FreeModuleElement_generic_dense, FourierEx
         return left.parent()._element_class(left.parent(), FreeModuleElement_generic_dense._add_(left, right))
     
     def __copy__(self) :
-        """
+        r"""
         Return a copy of ``self``.
         
         OUTPUT:
@@ -1343,6 +1359,7 @@ class ExpansionModuleVector_generic ( FreeModuleElement_generic_dense, FourierEx
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModuleVector_generic
             sage: emps = EquivariantMonoidPowerSeriesRing(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: em = ExpansionModule(Sequence([emps.one_element(), emps.one_element(), emps.one_element()]))
             sage: copy(ExpansionModuleVector_generic(em, [1,0,2])) == ExpansionModuleVector_generic(em, [1,0,2])

--- a/psage/modform/fourier_expansion_framework/gradedexpansions/fourierexpansionwrapper.py
+++ b/psage/modform/fourier_expansion_framework/gradedexpansions/fourierexpansionwrapper.py
@@ -25,7 +25,7 @@ AUTHOR :
 #===============================================================================
 
 class FourierExpansionWrapper :
-    """
+    r"""
     Abstract class for elements, which do not represent Fourier
     expansions on their own, but encapsulate one.
     
@@ -34,7 +34,7 @@ class FourierExpansionWrapper :
     """
     
     def fourier_expansion(self, cache = True) :
-        """
+        r"""
         The Fourier expansion which is associated with ``self``.
         
         INPUT:
@@ -67,7 +67,7 @@ class FourierExpansionWrapper :
                 return self.parent()._fourier_expansion_of_element(self)
             
     def _set_fourier_expansion(self, expansion ) :
-        """
+        r"""
         Set the cache for the Fourier expansion to an given monoid power series.
         
         INPUT:

--- a/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_ambient.py
+++ b/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_ambient.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Ambients of elements with Fourier expansion and partially known relations.
 
 AUTHOR :
@@ -44,7 +44,7 @@ GradedExpansionSubmodule_abstract = None
 #===============================================================================
 
 class GradedExpansionAmbient_abstract :
-    """
+    r"""
     A ring of graded expansions. This is a polynomial ring with relations
     and a mapping to an (equivariant) monoid power series. These should
     respect the given relations, but there can me more relations of the
@@ -53,7 +53,7 @@ class GradedExpansionAmbient_abstract :
     
     def __init__ ( self, base_ring_generators, generators, relations,
                    grading, all_relations = True, reduce_before_evaluating = True) :
-        """
+        r"""
         INPUT:
             - ``base_ring_generators``      -- A sequence of (equivariant) monoid power series with
                                                coefficient domain the base ring of the coefficient
@@ -96,10 +96,11 @@ class GradedExpansionAmbient_abstract :
         self.__grading = grading
         
         if base_ring_generators is None :
+            base_ring_generators = []
             base_ring_generators = Sequence([], universe = generators.universe().base_ring())
         self.__base_gens = \
           tuple([ self.base_ring()._element_class( self.base_ring(), self.base_ring().relations().ring()(g) )
-                  for g in self.__relations.ring().gens()[:len(base_ring_generators)]])
+                  for g in self.__relations.ring().gens()[:len(base_ring_generators)] ])
         self.__gens = \
          tuple([ self._element_class( self, g )
                  for g in self.__relations.ring().gens()[len(base_ring_generators):] ])
@@ -111,11 +112,11 @@ class GradedExpansionAmbient_abstract :
         self.__evaluation_hom = GradedExpansionEvaluationHomomorphism( self.__relations, self.__base_gen_expansions,
                                                                        self.__gen_expansions, self.__gen_expansions.universe(),
                                                                        reduce_before_evaluating )
-
+        
         self.__graded_submodules = dict()
     
     def ngens(self) :
-        """
+        r"""
         The number of generators of ``self`` over the base expansion ring.
         
         OUTPUT:
@@ -135,7 +136,7 @@ class GradedExpansionAmbient_abstract :
         return len(self.__gens)
     
     def gen(self, i = 0) :
-        """
+        r"""
         The `i`-th generator of ``self`` over the base expansion ring.
 
         INPUT:
@@ -158,7 +159,7 @@ class GradedExpansionAmbient_abstract :
         return self.__gens[i]
     
     def gens(self) :
-        """
+        r"""
         The generators of ``self`` over the base expansion ring.
         
         OUTPUT:
@@ -178,7 +179,7 @@ class GradedExpansionAmbient_abstract :
         return self.__gens
     
     def nbasegens(self) :
-        """
+        r"""
         Number of generators of the base expansion ring.
         
         OUTPUT:
@@ -201,7 +202,7 @@ class GradedExpansionAmbient_abstract :
         return len(self.__base_gens)
     
     def basegen(self, i) :
-        """
+        r"""
         The `i`-th generator of the base expansion ring.
         
         INPUT:
@@ -225,7 +226,7 @@ class GradedExpansionAmbient_abstract :
         return self.__base_gens[i]
     
     def basegens(self) :
-        """
+        r"""
         The generators of the base expansion ring.
         
         OUTPUT:
@@ -245,7 +246,7 @@ class GradedExpansionAmbient_abstract :
         return self.__base_gens
     
     def is_field(self) :
-        """
+        r"""
         OUTPUT:
             A boolean.
         
@@ -265,7 +266,7 @@ class GradedExpansionAmbient_abstract :
         return False
     
     def grading(self) :
-        """
+        r"""
         The grading imposed on this ring.
         
         OUTPUT:
@@ -285,7 +286,7 @@ class GradedExpansionAmbient_abstract :
         return self.__grading
     
     def relations(self) :
-        """
+        r"""
         The relation of the generators of this ring with in the underlying
         polynomial ring.
         
@@ -313,7 +314,7 @@ class GradedExpansionAmbient_abstract :
         return self.__relations
     
     def all_relations_known(self) :
-        """
+        r"""
         If ``True`` is returned any relation of the Fourier expansions associated
         with elements of this ring - thought of as expansions with
         infinite precision - implies that the relation is also contained
@@ -339,7 +340,7 @@ class GradedExpansionAmbient_abstract :
         return self.__all_relations
     
     def has_relation_free_generators(self) :
-        """
+        r"""
         If ``True`` is returned, there are no relations of the Fourier
         expansions - thought of as expansions with infinite precision.
         
@@ -367,7 +368,7 @@ class GradedExpansionAmbient_abstract :
         return self.__all_relations and self.__relations.is_zero()
     
     def _generator_expansions(self) :
-        """
+        r"""
         The generators' Fourier expansion within a common parent.
         
         OUTPUT:
@@ -389,7 +390,7 @@ class GradedExpansionAmbient_abstract :
         return self.__gen_expansions
     
     def _base_generator_expansions(self) :
-        """
+        r"""
         The Fourier expansions of the generators of the base expansion ring.
         
         OUTPUT:
@@ -413,7 +414,7 @@ class GradedExpansionAmbient_abstract :
     
     @cached_method
     def fourier_expansion_precision(self) :
-        """
+        r"""
         A precision which is obtained by all expansions of any element.
         
         OUTPUT:
@@ -437,7 +438,7 @@ class GradedExpansionAmbient_abstract :
     
     @cached_method
     def fourier_ring(self) :
-        """
+        r"""
         The ring that Fourier expansions of all elements of this
         ring will be contained in.
         
@@ -472,14 +473,14 @@ class GradedExpansionAmbient_abstract :
     
     #===========================================================================
     # def precision(self) :
-    #    """
+    #    r"""
     #    Return the minimal precision of any fourier expansion in this ring.
     #    """
     #    return min([g.precision() for g in self._generator_expansions()])
     #===========================================================================
 
     def _set_evaluation_hom(self, hom) :
-        """
+        r"""
         Set the homomorphism that maps every polynomial in the underlying
         polynomial ring to its expansion.
         
@@ -506,7 +507,7 @@ class GradedExpansionAmbient_abstract :
         self.__evaluation_hom = hom
     
     def _fourier_expansion_of_element(self, e) :
-        """
+        r"""
         The Fourier expansion of an element `e`.
         
         INPUT:
@@ -537,7 +538,7 @@ class GradedExpansionAmbient_abstract :
     
 #===============================================================================
 #    def graded_submodules_are_free(self) :
-#        """
+#        r"""
 #        If ``True`` is returned, there are no relations within the module
 #        formed by the Fourier expansions - thought of as expansions with
 #        infinite precision - for a fixed grading value.
@@ -560,7 +561,7 @@ class GradedExpansionAmbient_abstract :
 #===============================================================================
 
     def _graded_monoms(self, index) :
-        """
+        r"""
         Return all monoms in the generators that have a given grading index.
         
         INPUT:
@@ -585,7 +586,7 @@ class GradedExpansionAmbient_abstract :
         raise NotImplementedError
 
     def graded_submodule(self, indices, **kwds) :
-        """
+        r"""
         The submodule which contains all elements of given 
         grading values.
         
@@ -658,7 +659,7 @@ class GradedExpansionAmbient_abstract :
         return self.__graded_submodules[indices] 
     
     def _submodule(self, arg, *args, **kwds) :
-        """
+        r"""
         Return a submodule of ``self``.
         
         INPUT:
@@ -683,7 +684,7 @@ class GradedExpansionAmbient_abstract :
             raise NotImplementedError
 
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -719,7 +720,7 @@ class GradedExpansionAmbient_abstract :
         return c
     
     def construction(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -737,7 +738,7 @@ class GradedExpansionAmbient_abstract :
                  self.base_ring() )
 
     def _element_constructor_(self, x) :
-        """
+        r"""
         INPUT:
             - `x` -- An element of the underlying polynomial ring or
                      an element in a submodule of graded expansions.
@@ -781,7 +782,7 @@ class GradedExpansionAmbient_abstract :
         raise TypeError( "The element %s cannot be converted into %s," % (x, self) )
 
     def __hash__(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *

--- a/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_element.py
+++ b/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_element.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Elements wrapping a Fourier expansion which partially known relations.
 
 AUTHOR :
@@ -38,12 +38,12 @@ import operator
 #===============================================================================
 
 class GradedExpansion_abstract ( FourierExpansionWrapper ) :
-    """
+    r"""
     An abstract graded expansion.
     """
     
     def __init__(self, parent, polynomial) :
-        """
+        r"""
         INPUT:
             - ``parent``     -- An instance of :class:~`fourier_expansion_framework.gradedexpansions.gradedexpansion_ambient.GradedExpansionAmbient_abstract`.
             - ``polynomial`` -- A polynomial in the polynomial ring underlying the parent.
@@ -64,7 +64,7 @@ class GradedExpansion_abstract ( FourierExpansionWrapper ) :
         self.__polynomial = polynomial
         
     def polynomial(self) :
-        """
+        r"""
         The underlying polynomial.
         
         OUTPUT:
@@ -91,7 +91,7 @@ class GradedExpansion_abstract ( FourierExpansionWrapper ) :
         return self.__polynomial
     
     def _reduce_polynomial(self, set_polynomial = True) :
-        """
+        r"""
         The Groebner reduced underlying polynomial.
 
         INPUT:
@@ -129,7 +129,7 @@ class GradedExpansion_abstract ( FourierExpansionWrapper ) :
             return self.parent().relations().reduce(self.__polynomial)
     
     def homogeneous_components(self) :
-        """
+        r"""
         Split the underlying polynomial with respect to grading imposed on
         the parent.
         
@@ -180,7 +180,7 @@ class GradedExpansion_abstract ( FourierExpansionWrapper ) :
         return components
 
     def exponents(self) :
-        """
+        r"""
         The exponents of the underlying polynomial.
         
         OUTPUT:
@@ -211,7 +211,7 @@ class GradedExpansion_abstract ( FourierExpansionWrapper ) :
             return map(tuple, self.polynomial().exponents())
 
     def grading_index(self) :
-        """
+        r"""
         If ``self`` is homogeneous, return the index of ``self`` with respect to
         the grading imposed on the parent. Otherwise, a ``ValueError`` is raised.
         
@@ -249,7 +249,7 @@ class GradedExpansion_abstract ( FourierExpansionWrapper ) :
         return cps.keys()[0]
     
     def _add_(left, right) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -269,7 +269,7 @@ class GradedExpansion_abstract ( FourierExpansionWrapper ) :
                 left.polynomial() + right.polynomial() )
         
     def _lmul_(self, c) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -292,7 +292,7 @@ class GradedExpansion_abstract ( FourierExpansionWrapper ) :
                     self.polynomial() * c )
         
     def _rmul_(self, c) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -315,7 +315,7 @@ class GradedExpansion_abstract ( FourierExpansionWrapper ) :
                     c * self.polynomial() )
             
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -364,14 +364,14 @@ class GradedExpansion_abstract ( FourierExpansionWrapper ) :
 #===============================================================================
 
 class GradedExpansion_class ( GradedExpansion_abstract, AlgebraElement ) :
-    """
+    r"""
     A graded expansion which is element of an algebra.
     
     SEE:
         :class:`fourier_expansion_framework.gradedexpansions.gradedexpansion_ring.GradedExpansionRing_class`.
     """
     def __init__(self, parent, polynomial) :
-        """
+        r"""
         INPUT:
             - ``parent``     -- An instance of :class:~`fourier_expansion_framework.gradedexpansions.gradedexpansion_ring.GradedExpansionRing_class`.
             - ``polynomial`` -- A polynomial in the polynomial ring underlying the parent.
@@ -392,7 +392,7 @@ class GradedExpansion_class ( GradedExpansion_abstract, AlgebraElement ) :
         GradedExpansion_abstract.__init__(self, parent, polynomial)        
         
     def _mul_(left, right) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -411,7 +411,7 @@ class GradedExpansion_class ( GradedExpansion_abstract, AlgebraElement ) :
                 left.polynomial() * right.polynomial() )
 
     def __hash__(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -430,7 +430,7 @@ class GradedExpansion_class ( GradedExpansion_abstract, AlgebraElement ) :
         return hash(self.polynomial())
     
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -447,7 +447,7 @@ class GradedExpansion_class ( GradedExpansion_abstract, AlgebraElement ) :
         return "Graded expansion %s" % (self.polynomial(),)
     
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -459,12 +459,12 @@ class GradedExpansion_class ( GradedExpansion_abstract, AlgebraElement ) :
             sage: P.<a,b> = QQ[]
             sage: ger = GradedExpansionRing_class(Sequence([MonoidPowerSeries(mps, {1: 1}, mps.monoid().filter(4))]), Sequence([MonoidPowerSeries(mps, {1: 1, 2: 3}, mps.monoid().filter(4))]), P.ideal(a - b), DegreeGrading((1,2)))
             sage: latex( GradedExpansion_class(ger, a^2) )
-            Graded expansion a^{2}
+            \text{Graded expansion }a^{2}
         """
-        return "Graded expansion %s" % latex(self.polynomial())
+        return r"\text{Graded expansion }%s" % latex(self.polynomial())
 
 class GradedExpansionVector_class ( GradedExpansion_abstract, ModuleElement ) :
-    """
+    r"""
     A graded expansion which is element of a module.
         
     SEE:
@@ -472,7 +472,7 @@ class GradedExpansionVector_class ( GradedExpansion_abstract, ModuleElement ) :
     """
 
     def __init__(self, parent, polynomial) :
-        """
+        r"""
         INPUT:
             - ``parent``     -- An instance of :class:~`fourier_expansion_framework.gradedexpansions.gradedexpansion_module.GradedExpansionModule_class`.
             - ``polynomial`` -- A polynomial in the polynomial ring underlying the parent.
@@ -495,7 +495,7 @@ class GradedExpansionVector_class ( GradedExpansion_abstract, ModuleElement ) :
         GradedExpansion_abstract.__init__(self, parent, polynomial)
 
     def __hash__(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import *
@@ -516,7 +516,7 @@ class GradedExpansionVector_class ( GradedExpansion_abstract, ModuleElement ) :
         return hash(self.polynomial())
     
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import *
@@ -555,7 +555,7 @@ class GradedExpansionVector_class ( GradedExpansion_abstract, ModuleElement ) :
         return "Graded expansion vector %s" % (tuple(vector_repr),)
     
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import *
@@ -569,7 +569,7 @@ class GradedExpansionVector_class ( GradedExpansion_abstract, ModuleElement ) :
             sage: P.<a,b> = QQ[]
             sage: ger = GradedExpansionModule_class(Sequence([MonoidPowerSeries(mps, {1: 1}, mps.monoid().filter(4))]), Sequence([MonoidPowerSeries(mpsm, {1: m([1,1,1]), 2: m([1,3,-3])}, mpsm.monoid().filter(4))]), P.ideal(0), DegreeGrading((1,2)))
             sage: latex( GradedExpansionVector_class(ger, a*b) )
-            Graded expansion vector \left(a\right)
+            \text{Graded expansion vector }\left(a\right)
         """
         poly = self.polynomial()
         
@@ -591,5 +591,5 @@ class GradedExpansionVector_class ( GradedExpansion_abstract, ModuleElement ) :
                 c += poly[e] * prod(map(operator.pow, coefficient_monomials, e[:self.parent().nbasegens()]))
             vector_repr[ind] += c
                 
-        return "Graded expansion vector %s" % (latex(tuple(vector_repr)),)
+        return r"\text{Graded expansion vector }%s" % (latex(tuple(vector_repr)),)
     

--- a/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_functor.py
+++ b/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_functor.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Functors for ring and modules of graded expansions.
 
 AUTHOR :
@@ -40,7 +40,7 @@ import operator
 #===============================================================================
 
 class GradedExpansionFunctor ( ConstructionFunctor ) :
-    """
+    r"""
     Constructing a graded expansion ring or module from a base ring.
     """
     
@@ -48,7 +48,7 @@ class GradedExpansionFunctor ( ConstructionFunctor ) :
     
     def __init__( self, base_ring_generators, generators,
                   relations, grading, all_relations = True, reduce_before_evaluating = True ) :
-        """
+        r"""
         INPUT:
         - ``base_ring_generators``      -- A sequence of (equivariant) monoid power series with
                                            coefficient domain the base ring of the coefficient
@@ -112,7 +112,7 @@ class GradedExpansionFunctor ( ConstructionFunctor ) :
         ConstructionFunctor.__init__( self, Rings(), Rings() )
         
     def __call__(self, R) :
-        """
+        r"""
         The graded expansion ring with the given generators over the base
         ring `R`.
                 
@@ -161,7 +161,7 @@ class GradedExpansionFunctor ( ConstructionFunctor ) :
         raise RuntimeError( "The generators' universe must be an algebra or a module." )
         
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -197,7 +197,7 @@ class GradedExpansionFunctor ( ConstructionFunctor ) :
         return c
 
     def merge(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -240,12 +240,12 @@ class GradedExpansionFunctor ( ConstructionFunctor ) :
 #===============================================================================
 
 class GradedExpansionBaseringInjection ( Morphism ) :
-    """
+    r"""
     The injection of the base ring into a ring of graded expansions.
     """
     
     def __init__(self, domain, codomain ) :
-        """
+        r"""
         INPUT:
             - ``domain``   -- A ring.
             - ``codomain`` -- A ring of graded expansions.
@@ -269,7 +269,7 @@ class GradedExpansionBaseringInjection ( Morphism ) :
         self._repr_type_str = "Base ring injection of %s" % (codomain,)
 
     def _call_(self, x) :
-        """
+        r"""
         INPUT:
             - `x` -- An element of the domain.
         
@@ -292,7 +292,7 @@ class GradedExpansionBaseringInjection ( Morphism ) :
         return self.codomain()._element_constructor_(x)
             
     def _call_with_args(self, x, *args, **kwds):
-        """
+        r"""
         INPUT:
             - `x`      -- An element of the domain.
             - `args``  -- Will be forwarded to the codomain's element constructor. 
@@ -320,13 +320,13 @@ class GradedExpansionBaseringInjection ( Morphism ) :
 #===============================================================================
 
 class GradedExpansionEvaluationHomomorphism ( Morphism ) :
-    """
+    r"""
     The evaluation of a polynomial by substituting the Fourier expansions
     attached to a ring or module of graded expansions.
     """
     
     def __init__(self, relations, base_ring_images, images, codomain, reduce = True) :
-        """
+        r"""
         INPUT:
             - ``relations``        -- An ideal in a polynomial ring.
             - ``base_ring_images`` -- A list or sequence of elements of a ring of (equivariant)
@@ -356,7 +356,7 @@ class GradedExpansionEvaluationHomomorphism ( Morphism ) :
         self._repr_type_str = "Evaluation homomorphism from %s to %s" % (relations.ring(), codomain)
 
     def _call_with_args(self, x, *args, **kwds) :
-        """
+        r"""
         SEE:
             :meth:~`._call_`.
         
@@ -378,7 +378,7 @@ class GradedExpansionEvaluationHomomorphism ( Morphism ) :
         return self._call_(x)
     
     def _call_(self, x) :
-        """
+        r"""
         INPUT:
             - `x` -- A polynomial.
         

--- a/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_grading.py
+++ b/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_grading.py
@@ -36,13 +36,13 @@ from sage.structure.all import Sequence
 from sage.structure.sage_object import SageObject
 
 class Grading_abstract ( SageObject ) :
-    """
+    r"""
     A common interface for monomial gradings of polynomial rings
     `R[x_1, .., x_n]`.
     """
     
     def ngens(self) :
-        """
+        r"""
         The number of generators of the polynomial ring.
         
         OUTPUT:
@@ -58,7 +58,7 @@ class Grading_abstract ( SageObject ) :
         raise NotImplementedError
         
     def gen(self, i) :
-        """
+        r"""
         The grading associated to the `i`-th generator of the polynomial ring.
         
         INPUT:
@@ -77,7 +77,7 @@ class Grading_abstract ( SageObject ) :
         raise NotImplementedError
         
     def gens(self) :
-        """
+        r"""
         The gradings of the generators of the polynomial ring.
         
         OUTPUT:
@@ -93,7 +93,7 @@ class Grading_abstract ( SageObject ) :
         raise NotImplementedError
         
     def index(self, x) :
-        """
+        r"""
         The grading value of `x` with respect to this grading. 
 
         INPUT:
@@ -112,7 +112,7 @@ class Grading_abstract ( SageObject ) :
         raise NotImplementedError
         
     def basis(self, index, vars = None) :
-        """
+        r"""
         All monomials that are have given grading index involving only the
         given variables.
         
@@ -135,7 +135,7 @@ class Grading_abstract ( SageObject ) :
         raise NotImplementedError
     
     def subgrading(self, gens) :
-        """
+        r"""
         The grading of same type for the ring with only the variables given by
         ``gens``.
         
@@ -155,7 +155,7 @@ class Grading_abstract ( SageObject ) :
         raise NotImplementedError
     
     def __contains__(self, x) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: 1 in Grading_abstract()
@@ -166,7 +166,7 @@ class Grading_abstract ( SageObject ) :
         raise NotImplementedError
     
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: Grading_abstract()
@@ -175,26 +175,26 @@ class Grading_abstract ( SageObject ) :
         return "A grading"
     
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: latex( Grading_abstract() )
-            A grading
+            \text{A grading}
         """
-        return "A grading"
+        return r"\text{A grading}"
                 
 #===============================================================================
 # DegreeGrading
 #===============================================================================
 
 class DegreeGrading( Grading_abstract ) :
-    """
+    r"""
     This class implements a monomial grading for a polynomial ring
     `R[x_1, .., x_n]`.
     """
   
     def __init__( self, degrees ) :
-        """
+        r"""
         INPUT:
             - ``degrees`` -- A list or tuple of `n` positive integers.
         
@@ -209,7 +209,7 @@ class DegreeGrading( Grading_abstract ) :
         self.__module_basis = self.__module.basis()
         
     def ngens(self) :
-        """
+        r"""
         The number of generators of the polynomial ring.
         
         OUTPUT:
@@ -225,7 +225,7 @@ class DegreeGrading( Grading_abstract ) :
         return len(self.__degrees)
      
     def gen(self, i) :
-        """
+        r"""
         The number of generators of the polynomial ring.
         
         OUTPUT:
@@ -246,7 +246,7 @@ class DegreeGrading( Grading_abstract ) :
         raise ValueError("Generator %s does not exist." % (i,))
     
     def gens(self) :
-        """
+        r"""
         The gradings of the generators of the polynomial ring.
         
         OUTPUT:
@@ -262,7 +262,7 @@ class DegreeGrading( Grading_abstract ) :
         return self.__degrees
                 
     def index(self, x) :
-        """
+        r"""
         The grading value of `x` with respect to this grading. 
 
         INPUT:
@@ -290,7 +290,7 @@ class DegreeGrading( Grading_abstract ) :
         return sum( map(mul, x, self.__degrees) )
         
     def basis(self, index, vars = None) :
-        """
+        r"""
         All monomials that are have given grading index involving only the
         given variables.
         
@@ -334,7 +334,7 @@ class DegreeGrading( Grading_abstract ) :
         return res
 
     def subgrading(self, gens) :
-        """
+        r"""
         The grading of same type for the ring with only the variables given by
         ``gens``.
         
@@ -355,7 +355,7 @@ class DegreeGrading( Grading_abstract ) :
         return DegreeGrading([self.__degrees[i] for i in gens])
         
     def __contains__(self, x) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: g = DegreeGrading([5,2,3])
@@ -367,7 +367,7 @@ class DegreeGrading( Grading_abstract ) :
         return isinstance(x, (int, Integer)) 
     
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: g = DegreeGrading([5,2,3])
@@ -384,7 +384,7 @@ class DegreeGrading( Grading_abstract ) :
         return c
     
     def __hash__(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: hash( DegreeGrading([5,2,3]) )
@@ -394,7 +394,7 @@ class DegreeGrading( Grading_abstract ) :
         return hash(self.__degrees)
     
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: DegreeGrading([5,2,3])
@@ -403,22 +403,22 @@ class DegreeGrading( Grading_abstract ) :
         return "Degree grading %s" % str(self.__degrees)
     
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: latex( DegreeGrading([5,2,3]) )
-            Degree grading $\left(5, 2, 3\right)$
+            \text{Degree grading } \left(5, 2, 3\right)
         """
-        return "Degree grading $%s$" % latex(self.__degrees)
+        return r"\text{Degree grading }" + latex(self.__degrees)
 
 class TrivialGrading ( Grading_abstract ) :
-    """
+    r"""
     A grading for a polynomial ring `R[x_1, .., x_n]` assigning to every
     element the same, arbitrary index.
     """
     
     def __init__(self, nmb_generators, index) :
-        """
+        r"""
         INPUT:
             - ``nmb_generators`` -- A positive integer; The number `n` of
                                     variables of the graded polynomial ring.
@@ -434,7 +434,7 @@ class TrivialGrading ( Grading_abstract ) :
         self.__index = index
         
     def ngens(self) :
-        """
+        r"""
         The number of generators of the polynomial ring.
         
         OUTPUT:
@@ -448,7 +448,7 @@ class TrivialGrading ( Grading_abstract ) :
         return self.__ngens
     
     def gen(self, i) :
-        """
+        r"""
         The number of generators of the polynomial ring.
         
         OUTPUT:
@@ -469,7 +469,7 @@ class TrivialGrading ( Grading_abstract ) :
         raise ValueError("Generator %s does not exist." % (i,))
     
     def gens(self) :
-        """
+        r"""
         The gradings of the generators of the polynomial ring.
         
         OUTPUT:
@@ -483,7 +483,7 @@ class TrivialGrading ( Grading_abstract ) :
         return tuple(self.__ngens*[self.__index])
     
     def index(self, x) :
-        """
+        r"""
         The grading value of `x` with respect to this grading. 
 
         INPUT:
@@ -507,7 +507,7 @@ class TrivialGrading ( Grading_abstract ) :
         return self.__index
     
     def basis(self, index, vars = None) :
-        """
+        r"""
         All degree one monomials that are have given grading index involving only the
         given variables.
         
@@ -537,7 +537,7 @@ class TrivialGrading ( Grading_abstract ) :
             return [] 
         
     def subgrading(self, gens) :
-        """
+        r"""
         The grading of same type for the ring with only the variables given by
         ``gens``.
         
@@ -557,7 +557,7 @@ class TrivialGrading ( Grading_abstract ) :
         return TrivialGrading(len(gens), self.__index)
     
     def __contains__(self, x) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: g = TrivialGrading( 3, "t" )
@@ -571,7 +571,7 @@ class TrivialGrading ( Grading_abstract ) :
         return x == self.__index
     
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: g = TrivialGrading( 3, "t" )
@@ -592,7 +592,7 @@ class TrivialGrading ( Grading_abstract ) :
         return c
     
     def __hash__(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: hash( TrivialGrading( 3, "t" ) )
@@ -602,7 +602,7 @@ class TrivialGrading ( Grading_abstract ) :
         return reduce(xor, map(hash, [self.__ngens, self.__index]))
     
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: TrivialGrading( 3, "t" )
@@ -612,11 +612,11 @@ class TrivialGrading ( Grading_abstract ) :
                 % (self.__ngens, repr(self.__index))
     
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import *
             sage: latex( TrivialGrading( 3, "t" ) )
-            Trivial grading on $3$ generators with index $\texttt{t}$
+            \text{Trivial grading on $3$ generators with index $\verb|t|$}
         """
-        return "Trivial grading on $%s$ generators with index $%s$" \
+        return r"\text{Trivial grading on $%s$ generators with index $%s$}" \
                 % (latex(self.__ngens), latex(self.__index))

--- a/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_module.py
+++ b/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_module.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Modules of elements with Fourier expansion and partially known relations. 
 
 AUTHOR :
@@ -41,7 +41,7 @@ import operator
 #===============================================================================
 
 class GradedExpansionModule_class ( GradedExpansionAmbient_abstract, Module ) :
-    """
+    r"""
     A class for a module of vector valued graded expansions
     over an ambient of graded expansions, that might also be trivial.
     
@@ -51,7 +51,7 @@ class GradedExpansionModule_class ( GradedExpansionAmbient_abstract, Module ) :
     
     def __init__ ( self, base_ring_generators, generators, relations,
                    grading, all_relations = True, reduce_before_evaluating = True ) :
-        """
+        r"""
         The degree one part of the monomials that correspond to generators over the
         base expansion ring will serve as the coordinates of the elements.
         
@@ -114,7 +114,7 @@ class GradedExpansionModule_class ( GradedExpansionAmbient_abstract, Module ) :
           convert_method_name = "_graded_expansion_submodule_to_graded_ambient_" )
 
     def _graded_monoms(self, index) :
-        """
+        r"""
         Return all monoms in the generators that have a given grading index.
         
         INPUT:
@@ -157,7 +157,7 @@ class GradedExpansionModule_class ( GradedExpansionAmbient_abstract, Module ) :
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import DegreeGrading
-            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_ring import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_module import *
             sage: m = FreeModule(QQ, 3)
             sage: mpsm = MonoidPowerSeriesModule(m, NNMonoid(False))
             sage: mps = mpsm.base_ring()
@@ -179,7 +179,7 @@ class GradedExpansionModule_class ( GradedExpansionAmbient_abstract, Module ) :
         return Module._coerce_map_from_(self, other)
 
     def _element_constructor_(self, x) :
-        """
+        r"""
         INPUT:
             - `x` -- A zero integer, an element of the underlying polynomial ring or
                      an element in a submodule of graded expansions.
@@ -192,7 +192,7 @@ class GradedExpansionModule_class ( GradedExpansionAmbient_abstract, Module ) :
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import DegreeGrading
-            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_ring import *
+            sage: from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_module import *
             sage: m = FreeModule(QQ, 3)
             sage: mpsm = MonoidPowerSeriesModule(m, NNMonoid(False))
             sage: mps = mpsm.base_ring()
@@ -228,7 +228,7 @@ class GradedExpansionModule_class ( GradedExpansionAmbient_abstract, Module ) :
                 + ''.join(map(lambda e: repr(e.polynomial()) + ", ", self.gens()))[:-2]
                 
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import *
@@ -240,7 +240,7 @@ class GradedExpansionModule_class ( GradedExpansionAmbient_abstract, Module ) :
             sage: mps = mpsm.base_ring()
             sage: ger = GradedExpansionModule_class(Sequence([MonoidPowerSeries(mps, {1: 1}, mps.monoid().filter(4))]), Sequence([MonoidPowerSeries(mpsm, {1: m([1,1,1]), 2: m([1,3,-3])}, mpsm.monoid().filter(4))]), PolynomialRing(QQ, ['a', 'b']).ideal(0), DegreeGrading((1,2)))
             sage: latex(ger)
-            Graded expansion module with generators b
+            \text{Graded expansion module with generators }b
         """
-        return "Graded expansion module with generators " \
+        return r"\text{Graded expansion module with generators }" \
                 + ''.join(map(lambda e: latex(e.polynomial()) + ", ", self.gens()))[:-2]

--- a/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_ring.py
+++ b/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_ring.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Rings of elements with Fourier expansion and partially known relations. 
 
 AUTHOR :
@@ -41,7 +41,7 @@ import operator
 #===============================================================================
 
 class GradedExpansionRing_class ( GradedExpansionAmbient_abstract, Algebra ) :
-    """
+    r"""
     A class for a ring of graded expansions over an ambient of graded expansions,
     that might also be trivial.
     That is, a polynomial ring with relations and a mapping to an (equivariant)
@@ -50,7 +50,7 @@ class GradedExpansionRing_class ( GradedExpansionAmbient_abstract, Algebra ) :
     
     def __init__ ( self, base_ring_generators, generators,
                    relations, grading, all_relations = True, reduce_before_evaluating = True) :
-        """
+        r"""
         The degree one part of the monomials that correspond to generators over the
         base expansion ring will serve as the coordinates of the elements.
         
@@ -105,14 +105,17 @@ class GradedExpansionRing_class ( GradedExpansionAmbient_abstract, Algebra ) :
             Algebra.__init__(self, R)
 
         GradedExpansionAmbient_abstract.__init__(self, base_ring_generators, generators, relations, grading, all_relations, reduce_before_evaluating)
-        
+
         self._populate_coercion_lists_(
           coerce_list = [GradedExpansionBaseringInjection(self.base_ring(), self)],
-          convert_list = [self.relations().ring()],
+# This is deactivated since it leads to errors in the coercion system for Sage 4.8
+# TODO: Find out why
+#          convert_list = [self.relations().ring()],
+          convert_list = [],
           convert_method_name = "_graded_expansion_submodule_to_graded_ambient_" )
 
     def _graded_monoms(self, index) :
-        """
+        r"""
         Return all monoms in the generators that have a given grading index.
         
         INPUT:
@@ -144,7 +147,7 @@ class GradedExpansionRing_class ( GradedExpansionAmbient_abstract, Algebra ) :
         return [ self(reduce(operator.mul, g)) if len(g) > 1 else g[0] for g in module_gens ]
 
     def _coerce_map_from_(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import *
@@ -170,7 +173,7 @@ class GradedExpansionRing_class ( GradedExpansionAmbient_abstract, Algebra ) :
         return Algebra._coerce_map_from_(self, other)
 
     def _element_constructor_(self, x) :
-        """
+        r"""
         INPUT:
             - `x` -- An integer, an element of the underlying polynomial ring or
                      an element in a submodule of graded expansions.
@@ -202,7 +205,7 @@ class GradedExpansionRing_class ( GradedExpansionAmbient_abstract, Algebra ) :
         return GradedExpansionAmbient_abstract._element_constructor_(self, x)
 
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -218,7 +221,7 @@ class GradedExpansionRing_class ( GradedExpansionAmbient_abstract, Algebra ) :
                 + ''.join(map(lambda e: repr(e.polynomial()) + ", ", self.gens()))[:-2]
                 
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -228,7 +231,7 @@ class GradedExpansionRing_class ( GradedExpansionAmbient_abstract, Algebra ) :
             sage: mps = MonoidPowerSeriesRing(QQ, NNMonoid(False))
             sage: ger = GradedExpansionRing_class(Sequence([MonoidPowerSeries(mps, {1: 1}, mps.monoid().filter(4))]), Sequence([MonoidPowerSeries(mps, {1: 1, 2: 3}, mps.monoid().filter(4))]), PolynomialRing(QQ, ['a', 'b']).ideal(0), DegreeGrading((1,2)))
             sage: latex(ger)
-            Graded expansion ring with generators b
+            \text{Graded expansion ring with generators }b
         """
-        return "Graded expansion ring with generators "\
+        return r"\text{Graded expansion ring with generators }"\
                 + ''.join(map(lambda e: latex(e.polynomial()) + ", ", self.gens()))[:-2]

--- a/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_submodule.py
+++ b/psage/modform/fourier_expansion_framework/gradedexpansions/gradedexpansion_submodule.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Finite dimensional submodules of a ring or module of graded expansions. 
 
 AUTHOR :
@@ -58,7 +58,7 @@ from sage.structure.sequence import Sequence
 #===============================================================================
 
 def GradedExpansionSubmodule(arg1, arg2) :
-    """
+    r"""
     A submodule of either a graded ring, module or submodule.
     
     INPUT (first possibility):
@@ -116,7 +116,7 @@ def GradedExpansionSubmodule(arg1, arg2) :
 #===============================================================================
 
 class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
-    """
+    r"""
     Abstract implementation of a finite dimensional module of graded expansions
     within an ambient.
     
@@ -125,7 +125,7 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
     """
     
     def __init__(self, graded_ambient, basis, degree, **kwds) :
-        """
+        r"""
         INPUT:
             - ``graded_ambient`` -- An instance of :class:~`fourier_expansion_framework.gradedexpansions.gradedexpansion_ambient.GradedExpansionAmbient_abstract`.
             - ``basis``          -- A tuple, list or sequence of elements of the graded ambient.
@@ -167,7 +167,7 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
                                                                   universe = graded_ambient.fourier_ring(), check = False ))
         
     def graded_ambient(self) :
-        """
+        r"""
         The graded ambientm, namely, the graded ring or module
         ``self`` is a submodule of.
         
@@ -192,7 +192,7 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
         return self.__graded_ambient
 
     def _basis_in_graded_ambient(self) :
-        """
+        r"""
         A basis for ``self`` in terms of elements of the graded ambient.
         
         OUTPUT:
@@ -217,7 +217,7 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
 
     @cached_method
     def _reduced_basis_polynomials(self, coerce_to = None) :
-        """
+        r"""
         A list of reduced polynomials associated to the basis of ``self``
         within the graded ambient. If coerce_to is not None, these elements
         will first be coerced into ``coerce_to`` and the resulting polynomials
@@ -272,7 +272,7 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
         
     @cached_method
     def _non_zero_monomials(self, coerce_to = None) :
-        """
+        r"""
         A list of monomials which occur in the reduced polynomials
         associated with the basis of ``self``.
         
@@ -317,7 +317,7 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
 
     @cached_method
     def _monomial_homomorphism(self, coerce_to = None) :
-        """
+        r"""
         A homomorphism that maps the underlying module to a vector space
         where each component corresponds to a coefficient of the polynomial
         associated to elements of ``self`` within the graded ambient or
@@ -380,7 +380,7 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
           
           
     def _ambient_element_to_monomial_coefficients_generator(self, x, reduce = False, coerce_basis_to = None) :
-        """
+        r"""
         Given an element `x` of the graded ambient ring or space return a generator
         corresponding to the image of `x` with respect to the morphism returned
         by :meth:~`._monomial_homomorphism`.
@@ -436,7 +436,7 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
                  for m in self._non_zero_monomials(coerce_to = coerce_basis_to) ) 
 
     def coordinates(self, x, in_base_ring = True, force_ambigous = False) :
-        """
+        r"""
         The coordinates in ``self`` of an element either of the following:
             - The graded ambient,
             - An element of a submodule,
@@ -561,7 +561,7 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
         return ExpansionModule_abstract.coordinates(self, x, in_base_ring, force_ambigous)
         
     def _graded_expansion_submodule_to_graded_ambient_(self, x) :
-        """
+        r"""
         The element `x` of ``self`` as an element of the graded ambient ring or space.
         
         INPUT:
@@ -591,7 +591,7 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
         return sum( map(mul, self.coordinates(x), self._basis_in_graded_ambient()) )
 
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -612,7 +612,7 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
         return "Submodule of %s" % (self.__graded_ambient,)
     
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -628,16 +628,16 @@ class GradedExpansionSubmodule_abstract ( ExpansionModule_abstract ) :
             sage: ger = GradedExpansionRing_class(None, Sequence([MonoidPowerSeries(mps, {1 : 4, 2 : 3}, mps.monoid().filter_all()), MonoidPowerSeries(mps, {1 : 1, 2 : 3}, mps.monoid().filter_all()), MonoidPowerSeries(mps, {2 : 1, 3: 6, 4 : 9}, mps.monoid().filter_all())]), PolynomialRing(QQ, ['a', 'b', 'c']).ideal(0), DegreeGrading((1,2,3)))
             sage: ger2 = GradedExpansionRing_class(None, Sequence([MonoidPowerSeries(mps, {1 : 4, 2 : 3}, mps.monoid().filter_all()), MonoidPowerSeries(mps, {1 : 1, 2 : 3}, mps.monoid().filter_all()), MonoidPowerSeries(mps, {2 : 1, 3: 6, 4 : 9}, mps.monoid().filter_all())]), P.ideal(a - b), DegreeGrading((1,2,3)))
             sage: latex( GradedExpansionSubmodule_ambient_pid(ger, Sequence([ger.0, ger.1])) )
-            Submodule of Graded expansion ring with generators a, b, c
+            \text{Submodule of }\text{Graded expansion ring with generators }a , b , c
         """
-        return "Submodule of %s" % (latex(self.__graded_ambient),)
+        return r"\text{Submodule of }%s" % (latex(self.__graded_ambient),)
 
 #===============================================================================
 # GradedExpansionSubmodule_generic
 #===============================================================================
 
 class GradedExpansionSubmodule_generic ( GradedExpansionSubmodule_abstract, ExpansionModule_generic ) :
-    """
+    r"""
     A finite dimensional module of graded expansions within an ambient.
     
     SEE:
@@ -645,7 +645,7 @@ class GradedExpansionSubmodule_generic ( GradedExpansionSubmodule_abstract, Expa
     """
     
     def __init__(self, graded_ambient, basis, degree, **kwds) :
-        """
+        r"""
         INPUT:
             - ``graded_ambient`` -- An instance of :class:~`fourier_expansion_framework.gradedexpansions.gradedexpansion_ambient.GradedExpansionAmbient_abstract`.
             - ``basis``          -- A tuple, list or sequence of elements of the graded ambient.
@@ -678,7 +678,7 @@ class GradedExpansionSubmodule_generic ( GradedExpansionSubmodule_abstract, Expa
         ExpansionModule_generic.__init__(self, self._abstract_basis(), degree, **kwds)
 
     def change_ring(self, R):
-        """
+        r"""
         Return the ambient module of graded expansions over `R` with the same basis as ``self``.
         
         INPUT:
@@ -712,7 +712,7 @@ class GradedExpansionSubmodule_generic ( GradedExpansionSubmodule_abstract, Expa
         raise ValueError( "Associated expansion of graded ambient not defined over %s." % R )
 
     def basis(self) :
-        """
+        r"""
         A basis of ``self``.
         
         OUTPUT:
@@ -738,7 +738,7 @@ class GradedExpansionSubmodule_generic ( GradedExpansionSubmodule_abstract, Expa
         raise NotImplementedError    
 
     def hom(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -778,7 +778,7 @@ class GradedExpansionSubmodule_generic ( GradedExpansionSubmodule_abstract, Expa
 #===============================================================================
 
 def _span( self, gens, base_ring = None, check = True, already_echelonized = False ) :
-    """
+    r"""
     The submodule of graded expansions spanned by ``gens``.
     
     INPUT:
@@ -843,7 +843,7 @@ class GradedExpansionSubmodule_ambient_pid ( GradedExpansionSubmodule_abstract, 
     """
     
     def __init__(self, graded_ambient, basis, _element_class = None, **kwds) :
-        """
+        r"""
         INPUT:
             - ``graded_ambient`` -- An instance of :class:~`fourier_expansion_framework.gradedexpansions.gradedexpansion_ambient.GradedExpansionAmbient_abstract`.
             - ``basis``          -- A list or sequence of (equivariant) monoid power series.
@@ -883,7 +883,7 @@ class GradedExpansionSubmodule_ambient_pid ( GradedExpansionSubmodule_abstract, 
     span = _span
     
     def change_ring(self, R):
-        """
+        r"""
         Return the ambient module of graded expansions over `R` with the
         same basis as ``self``.
         
@@ -918,7 +918,7 @@ class GradedExpansionSubmodule_ambient_pid ( GradedExpansionSubmodule_abstract, 
         raise ValueError( "Associated expansion of graded ambient not defined over %s." % R )
 
     def hom(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -959,12 +959,12 @@ class GradedExpansionSubmodule_ambient_pid ( GradedExpansionSubmodule_abstract, 
 #===============================================================================
 
 class GradedExpansionSubmodule_submodule_pid ( GradedExpansionSubmodule_abstract, ExpansionModule_submodule_pid ) :
-    """
+    r"""
     A submodule of another module of graded expansions over a principal ideal domain.
     """
 
     def __init__(self, ambient, gens, element_class = None, **kwds) :
-        """
+        r"""
         INPUT:
             - ``ambient``       -- An instance of :class:~`.GradedExpansionSubmodule_submodule_pid` :class:~`.GradedExpansionSubmodule_submodule_pid` or .
             - ``gens``          -- A tuple, list or sequence of elements of ``ambient``.
@@ -1004,7 +1004,7 @@ class GradedExpansionSubmodule_submodule_pid ( GradedExpansionSubmodule_abstract
     span = _span
     
     def change_ring(self, R):
-        """
+        r"""
         Return the ambient module of graded expansions over `R` with the
         same basis as ``self``.
         
@@ -1040,7 +1040,7 @@ class GradedExpansionSubmodule_submodule_pid ( GradedExpansionSubmodule_abstract
         raise ValueError( "Associated expansion of graded ambient not defined over %s." % R )
 
     def hom(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -1082,12 +1082,12 @@ class GradedExpansionSubmodule_submodule_pid ( GradedExpansionSubmodule_abstract
 #===============================================================================
 
 class GradedExpansionSubmoduleVector_generic ( ExpansionModuleVector_generic ) :
-    """
+    r"""
     A generic implementation of an element in a module of graded expansions.
     """
     
     def __copy__(self) :
-        """
+        r"""
         Return a copy of ``self``.
         
         OUTPUT:
@@ -1113,7 +1113,7 @@ class GradedExpansionSubmoduleVector_generic ( ExpansionModuleVector_generic ) :
 
 
     def polynomial(self) :
-        """
+        r"""
         Return the polynomial associated to ``self`` in the graded ambient
         of its parent.
         

--- a/psage/modform/fourier_expansion_framework/modularforms/modularform_interfaces.py
+++ b/psage/modform/fourier_expansion_framework/modularforms/modularform_interfaces.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Interfaces for modular forms which admit Hecke actions or ring which have
 Maass lifts.
 

--- a/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_ambient.py
+++ b/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_ambient.py
@@ -2,7 +2,7 @@
 Ambients of monoid power series and ambients of equivariant monoid power series.
 
 AUTHOR :
-    -- Martin Raum (2010 - 02 - 10) Initial version
+    - Martin Raum (2010 - 02 - 10) Initial version
 """
 
 #===============================================================================
@@ -33,7 +33,7 @@ from sage.structure.element import Element
 #===============================================================================
 
 class MonoidPowerSeriesAmbient_abstract :
-    """
+    r"""
     Given some `K` module or algebra `A` and a monoid `S` filtered over
     a net `\Lambda` construct a module or ring of monoid power series.
     
@@ -43,7 +43,7 @@ class MonoidPowerSeriesAmbient_abstract :
     """
     
     def __init__(self, A, S) :
-        """
+        r"""
         INPUT:
             - `A` -- A ring or module.
             - `S` -- A monoid as implemented in :class:~`from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids.NNMonoid`.
@@ -62,7 +62,7 @@ class MonoidPowerSeriesAmbient_abstract :
             self._element_class = MonoidPowerSeries
 
     def is_exact(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing
@@ -73,7 +73,7 @@ class MonoidPowerSeriesAmbient_abstract :
         return False
         
     def monoid(self) :
-        """
+        r"""
         Return the index monoid of ``self``.
         
         OUTPUT:
@@ -89,7 +89,7 @@ class MonoidPowerSeriesAmbient_abstract :
         return self.__monoid
     
     def coefficient_domain(self) :
-        """
+        r"""
         The coefficient domain of ``self``.
         
         OUTPUT:
@@ -108,7 +108,7 @@ class MonoidPowerSeriesAmbient_abstract :
         return self.__coefficient_domain
     
     def _multiply_function(self) :
-        """
+        r"""
         Return the currect multiply function.
         
         The standard implementation of elements asks its parent to
@@ -132,7 +132,7 @@ class MonoidPowerSeriesAmbient_abstract :
         return self.__multiply_function
         
     def _set_multiply_function(self, f = None) :
-        """
+        r"""
         Set the multiply function that is decribed in :meth:~`._multiply_function`.
         If `f` is ``None`` an iteration over the decompositions in the
         monoid is used.
@@ -146,6 +146,7 @@ class MonoidPowerSeriesAmbient_abstract :
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import MonoidPowerSeries
             sage: mps = MonoidPowerSeriesRing(QQ, NNMonoid(False))
             sage: e = MonoidPowerSeries( mps, { 4 : 1, 5 : 2}, mps.monoid().filter_all() )
             sage: h = e * e # indirect doctest
@@ -174,7 +175,7 @@ class MonoidPowerSeriesAmbient_abstract :
         self.__multiply_function = mul
         
     def _coerce_map_from_(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing
@@ -189,7 +190,7 @@ class MonoidPowerSeriesAmbient_abstract :
                 return CallableConvertMap(other, self, self._element_constructor_)
     
     def _element_constructor_(self, x) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing
@@ -216,7 +217,7 @@ class MonoidPowerSeriesAmbient_abstract :
         raise (TypeError, "Cannot construct an element of %s" % (x))
     
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient import MonoidPowerSeriesAmbient_abstract
@@ -245,7 +246,7 @@ class MonoidPowerSeriesAmbient_abstract :
 #===============================================================================
 
 class EquivariantMonoidPowerSeriesAmbient_abstract :
-    """
+    r"""
     Given some ring or module `A`, a monoid `S` filtered over some originated
     net `\Lambda` such that all induced submonoids are finite, a group `G`, a
     semigroup `C` with a map `c \rightarrow \mathrm{Hom}(G, Aut_K(A))`, a
@@ -260,7 +261,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
     """
         
     def __init__(self, O, C, R) :
-        """
+        r"""
         INPUT:
             - `O` -- A monoid with an action of a group; As implemented in
                      :class:~`fourier_expansion_framework.monoidpowerseries.NNMonoid`.
@@ -289,7 +290,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
             self._element_class = EquivariantMonoidPowerSeries
     
     def is_exact(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing
@@ -300,7 +301,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         return False
     
     def coefficient_domain(self) :
-        """
+        r"""
         The domain of coefficients.
         
         OUTPUT:
@@ -316,7 +317,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         return self.__coefficient_domain
     
     def group(self) :
-        """
+        r"""
         The group acting on the index monoid.
         
         OUTPUT:
@@ -336,7 +337,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         return self.__action.group()
         
     def monoid(self) :
-        """
+        r"""
         The index monoid.
         
         OUTPUT:
@@ -352,7 +353,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         return self.__action.monoid()
     
     def action(self) :
-        """
+        r"""
         The index monoid with the action of a group.
         
         OUTPUT:
@@ -368,7 +369,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         return self.__action
     
     def characters(self) :
-        """
+        r"""
         The monoid of characters associated to the monoid index' group.
         
         OUTPUT:
@@ -384,7 +385,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         return self.__characters
         
     def representation(self) :
-        """
+        r"""
         The representation on the coefficient domain.
         
         OUTPUT:
@@ -400,7 +401,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         return self.__representation
     
     def _reduction_function(self) :
-        """
+        r"""
         The reduction function accepts an index `s`. It returns the pair
         reduction `(rs = g^-1 s, g)` of `s` with a group element `g`.
         
@@ -418,7 +419,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         return self.__reduction_function
     
     def _set_reduction_function(self, f = None) :
-        """
+        r"""
         Set the reduction function, explained in :class:~`._reduction_function`.
         If `f` is ``None`` the reduction function of the action is used.
         
@@ -442,7 +443,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         self.__reduction_function = self.__action._reduction_function()
     
     def _character_eval_function(self) :
-        """
+        r"""
         The character evaluation function. It accepts a character `c` and 
         a group element `g` and returns `c(g)`.
         
@@ -460,7 +461,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         return self.__character_eval_function 
     
     def _set_character_eval_function(self, f = None) :
-        """
+        r"""
         Set the character evaluation function. If `f` is ``None``, the 
         implementation of the character monoid is used.
         
@@ -484,7 +485,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         self.__character_eval_function = self.__characters._eval_function() 
     
     def _apply_function(self) :
-        """
+        r"""
         The apply function. It applies a group element `g` to an element `v`
         of the coefficient domain, the base space of the representation.
         
@@ -502,7 +503,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         return self.__apply_function
         
     def _set_apply_function(self, f = None) :
-        """
+        r"""
         Set the apply function. If `f` is ``None``, the implementation of
         the representation is used.
         
@@ -526,7 +527,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         self.__apply_function = self.__representation._apply_function()
         
     def _multiply_function(self) :
-        """
+        r"""
         The standard implementation of elements of this ring will ask its
         parent to provide multplication function, which has the
         following signature:
@@ -557,7 +558,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         return self.__multiply_function
     
     def _set_multiply_function(self, f = None) :
-        """
+        r"""
         Set the multiply function. If `f` is ``None`` an iteration over the
         decompositions in the monoid is used.
         
@@ -604,7 +605,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         self.__multiply_function = mul
 
     def _coerce_map_from_(self, other) :
-        """
+        r"""
         TODO:
           This is a stub. The dream is that representations know about
           compatible coercions and so would actions and characters. Then
@@ -627,7 +628,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
                     return CallableConvertMap(other, self, self._element_constructor_)
 
     def _element_constructor_(self, x) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing, EquivariantMonoidPowerSeriesRing
@@ -683,7 +684,7 @@ class EquivariantMonoidPowerSeriesAmbient_abstract :
         raise TypeError, "can't convert %s into %s" % (x, self)
         
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient import EquivariantMonoidPowerSeriesAmbient_abstract

--- a/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_basicmonoids.py
+++ b/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_basicmonoids.py
@@ -1,9 +1,9 @@
-"""
+r"""
 Implementation of base classes used as parameters for a ring of monoid 
 power series.
 
 AUTHOR :
-    -- Martin Raum (2009 - 07 - 25) Initial version
+    - Martin Raum (2009 - 07 - 25) Initial version
 """
 
 #===============================================================================
@@ -27,7 +27,7 @@ AUTHOR :
 
 from operator import xor
 from sage.misc.latex import latex
-from sage.rings.all import is_Ring
+from sage.categories.all import Rings
 from sage.rings.infinity import infinity
 from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
@@ -38,13 +38,13 @@ from sage.structure.sage_object import SageObject
 #===============================================================================
 
 class CharacterMonoid_class ( SageObject ) :
-    """
+    r"""
     The characters for an equivariant monoid power series must
     form a monoid. A basic implementation is given here.
     """
     
     def __init__(self, G, C, codomain, eval, C_multiplicative = True) :
-        """
+        r"""
         INPUT:
         
             - `G`          -- Every type accepted; Representative of a group which
@@ -62,7 +62,7 @@ class CharacterMonoid_class ( SageObject ) :
             The interface may change in the future, enforcing `G` to be a group.
         
         EXAMPLES::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             
         TESTS::
@@ -76,12 +76,12 @@ class CharacterMonoid_class ( SageObject ) :
         self.__C_multiplicative = C_multiplicative
 
     def ngens(self) :
-        """
+        r"""
         OUTPUT:
             An integer.
             
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm.ngens()
             1
@@ -92,12 +92,12 @@ class CharacterMonoid_class ( SageObject ) :
         return self.__C.ngens()
     
     def gen(self, i = 0) :
-        """
+        r"""
         OUTPUT:
             An instance of :class:`~.CharacterMonoidElement_class`.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm.gen()
             1
@@ -105,12 +105,12 @@ class CharacterMonoid_class ( SageObject ) :
         return CharacterMonoidElement_class(self, self.__C.gen(i))
     
     def gens(self) :
-        """
+        r"""
         OUTPUT:
             A tuple of instances of :class:`~.CharacterMonoidElement_class`.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm.gens()
             (1,)
@@ -118,7 +118,7 @@ class CharacterMonoid_class ( SageObject ) :
         return tuple(map(lambda c: CharacterMonoidElement_class(self, c), self.__C.gens()))
     
     def group(self) :
-        """
+        r"""
         Return the group, which is the common domain of all characters
         of this monoid of characters.
         
@@ -126,7 +126,7 @@ class CharacterMonoid_class ( SageObject ) :
             Of arbitrary type.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm.group()
             'ZZ'
@@ -134,14 +134,14 @@ class CharacterMonoid_class ( SageObject ) :
         return self.__G
 
     def codomain(self) :
-        """
+        r"""
         Return the common codomain of all characters of this monoid of characters.
 
         OUTPUT:
             A ring.
         
         EXAMPLES::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm.codomain()
             Rational Field
@@ -149,14 +149,14 @@ class CharacterMonoid_class ( SageObject ) :
         return self.__codomain
   
     def monoid(self) :
-        """
+        r"""
         Return the abstract monoid underlying this monoid of characters.
         
         OUTPUT:
             A monoid.
         
         EXAMPLES::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm.monoid()
             Trivial monoid
@@ -167,7 +167,7 @@ class CharacterMonoid_class ( SageObject ) :
         return self.__C
     
     def extends(self, other) :
-        """
+        r"""
         Decide whether ``self`` extends ``other``. Namely, whether there is a is an embedding of ``other``
         into ``self`` that is compatible with a common codomain. A negative answer does not mean
         that there is no such embedding.
@@ -179,7 +179,7 @@ class CharacterMonoid_class ( SageObject ) :
             A boolean.
         
         EXAMPLES::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm1 = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm2 = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm1 == cm2
@@ -188,14 +188,14 @@ class CharacterMonoid_class ( SageObject ) :
         return self == other
     
     def _is_C_multiplicative(self) :
-        """
+        r"""
         Return whether the underlying monoid is multiplicative.
         
         OUTPUT:
             A boolean.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm._is_C_multiplicative()
             True
@@ -203,7 +203,7 @@ class CharacterMonoid_class ( SageObject ) :
         return self.__C_multiplicative
     
     def _eval_function(self) :
-        """
+        r"""
         Return the evaluation function, mapping an element of the associated group and an element of ``self``
         to an element of the codomain.
         
@@ -211,7 +211,7 @@ class CharacterMonoid_class ( SageObject ) :
             A function with signature `g, c \mapsto e`. 
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: e = lambda g, c: 1
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, e)
             sage: e == cm._eval_function()
@@ -220,7 +220,7 @@ class CharacterMonoid_class ( SageObject ) :
         return self.__eval
         
     def _apply(self, g, c, b) :
-        """
+        r"""
         Apply `c(g)` to some element `b` by multiplication.
         
         INPUT:
@@ -233,7 +233,7 @@ class CharacterMonoid_class ( SageObject ) :
            An element of a ring. 
         
         EXAMPLES::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm._apply(1, 1, 2)
             2
@@ -241,9 +241,9 @@ class CharacterMonoid_class ( SageObject ) :
         return self.__eval(g, c) * b
 
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm1 = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm2 = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm1 == cm2
@@ -262,9 +262,9 @@ class CharacterMonoid_class ( SageObject ) :
         return c
     
     def __iter__(self) :
-        """
+        r"""
         TEST::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: list(cm)
             [1]
@@ -275,9 +275,9 @@ class CharacterMonoid_class ( SageObject ) :
         raise StopIteration
     
     def one_element(self) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm.one_element()
             1
@@ -285,7 +285,7 @@ class CharacterMonoid_class ( SageObject ) :
         return CharacterMonoidElement_class(self, self.__C.one_element())
 
     def __call__(self, x) :
-        """
+        r"""
         Convert an element to ``self``.
         
         INPUT:
@@ -295,7 +295,7 @@ class CharacterMonoid_class ( SageObject ) :
             An element of ``self``.
         
         TESTS::
-           sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+           sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: cm(1)
             1 
@@ -303,31 +303,31 @@ class CharacterMonoid_class ( SageObject ) :
         return CharacterMonoidElement_class(self, self.__C(x))
     
     def __hash__(self) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: d = dict([(cm.one_element, 0)]) # indirect doctest
         """
         return xor(hash(self.__C), hash(self.__G))
     
     def _repr_(self) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
             sage: CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             Character monoid over Trivial monoid
         """
         return "Character monoid over %s" % self.__C
     
     def _latex_(self) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
-            sage: CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
-            Character monoid over Trivial monoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, TrivialMonoid
+            sage: latex(CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1))
+            \text{Character monoid over } \text{Trivial monoid}
         """
-        return "Character monoid over %s" % latex(self.__C)
+        return r"\text{Character monoid over }" + latex(self.__C)
 
 #===============================================================================
 # CharacterMonoidElement_class
@@ -339,15 +339,14 @@ class CharacterMonoidElement_class ( SageObject ) :
     """
     
     def __init__(self, parent, c) :
-        """
+        r"""
         INPUT:
             - ``parent``  -- An instance of :class:`~.CharacterMonoid_class`; The parent of ``self``.
             - `c`         -- An element of a monoid; The element in the underlying monoid of ``parent``
                              associated to ``self``.
                 
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoidElement_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, CharacterMonoidElement_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: c = CharacterMonoidElement_class(cm, cm.monoid().one_element())
         """
@@ -355,13 +354,12 @@ class CharacterMonoidElement_class ( SageObject ) :
         self.__c = c
         
     def parent(self) :
-        """
+        r"""
         OUTPUT:
             An instance of :class:`~.CharacterMonoid_class`.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoidElement_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, CharacterMonoidElement_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: c = CharacterMonoidElement_class(cm, cm.monoid().one_element())
             sage: c.parent() is cm
@@ -370,15 +368,14 @@ class CharacterMonoidElement_class ( SageObject ) :
         return self.__parent
     
     def _monoid_element(self) :
-        """
+        r"""
         The underlying element of the monoid.
         
         OUTPUT:
             An element of a character.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoidElement_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, CharacterMonoidElement_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: c = CharacterMonoidElement_class(cm, cm.monoid().one_element())
             sage: c._monoid_element() == cm.monoid().one_element()
@@ -387,13 +384,12 @@ class CharacterMonoidElement_class ( SageObject ) :
         return self.__c
             
     def __call__(self, g) :
-        """
+        r"""
         OUTPUT:
             An element of the codomain of the parent.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoidElement_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, CharacterMonoidElement_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: c = CharacterMonoidElement_class(cm, cm.monoid().one_element())
             sage: c(2)
@@ -408,7 +404,7 @@ class CharacterMonoidElement_class ( SageObject ) :
         return self.parent()._eval_function()(g, self)
 
     def __mul__(left, right) :
-        """
+        r"""
         NOTE:
             If the underlying monoid is additive the character are nevertheless multiplied.
         
@@ -416,8 +412,7 @@ class CharacterMonoidElement_class ( SageObject ) :
             An instance of :class:`~.CharacterMonoidElement_class`.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoidElement_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, CharacterMonoidElement_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: c = CharacterMonoidElement_class(cm, cm.monoid().one_element())
             sage: c * c     # indirect doctest
@@ -437,10 +432,9 @@ class CharacterMonoidElement_class ( SageObject ) :
             return CharacterMonoidElement_class(left.parent(), left.__c + right.__c)
     
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoidElement_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, CharacterMonoidElement_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", ZZ, QQ, lambda g, c: 1, False)
             sage: c1 = CharacterMonoidElement_class(cm, cm.monoid().one_element())
             sage: c2 = CharacterMonoidElement_class(cm, cm.monoid().one_element())
@@ -458,13 +452,12 @@ class CharacterMonoidElement_class ( SageObject ) :
         return c
     
     def __hash__(self) :
-        """
+        r"""
         OUTPUT:
             An integer.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoidElement_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, CharacterMonoidElement_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: c1 = CharacterMonoidElement_class(cm, cm.monoid().one_element())
             sage: hash(c1)    # indirect doctest
@@ -474,13 +467,12 @@ class CharacterMonoidElement_class ( SageObject ) :
         return xor(hash(self.__parent), hash(self.__c))
     
     def _repr_(self) :
-        """
+        r"""
         OUTPUT:
             A string.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoidElement_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, CharacterMonoidElement_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: c1 = CharacterMonoidElement_class(cm, cm.monoid().one_element())
             sage: repr(c1)    # indirect doctest
@@ -489,17 +481,16 @@ class CharacterMonoidElement_class ( SageObject ) :
         return repr(self.__c)
     
     def _latex_(self) :
-        """
+        r"""
         OUTPUT:
             A string.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoidElement_class
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import CharacterMonoid_class, CharacterMonoidElement_class, TrivialMonoid
             sage: cm = CharacterMonoid_class("ZZ", TrivialMonoid(), QQ, lambda g, c: 1)
             sage: c1 = CharacterMonoidElement_class(cm, cm.monoid().one_element())
-            sage: repr(c1)    # indirect doctest
-            '1'
+            sage: latex(c1)    # indirect doctest
+            1
         """
         return latex(self.__c)
 
@@ -508,13 +499,13 @@ class CharacterMonoidElement_class ( SageObject ) :
 #===============================================================================
 
 class TrivialMonoid ( SageObject ) :
-    """
+    r"""
     A monoid with one element, which implements only functions that are necessary for
     being an arguemnt of :meth:`~.CharacterMonoid_class.__init__`.
     """
     
     def __init__(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialMonoid
             sage: m = TrivialMonoid()
@@ -522,7 +513,7 @@ class TrivialMonoid ( SageObject ) :
         SageObject.__init__(self)
     
     def ngens(self) :
-        """
+        r"""
         OUTPUT:
             An integer.
         
@@ -535,7 +526,7 @@ class TrivialMonoid ( SageObject ) :
         return 1
     
     def gen(self, i = 0) :
-        """
+        r"""
         OUTPUT:
             An integer.
         
@@ -555,7 +546,7 @@ class TrivialMonoid ( SageObject ) :
         raise ValueError, "Generator not defined."
     
     def gens(self) :
-        """
+        r"""
         OUTPUT:
             A tuple of integers.
         
@@ -568,7 +559,7 @@ class TrivialMonoid ( SageObject ) :
         return (Integer(1), )
     
     def one_element(self) :
-        """
+        r"""
         OUTPUT:
             An integer.
         
@@ -581,7 +572,7 @@ class TrivialMonoid ( SageObject ) :
         return Integer(1)
     
     def __call__(self, x) :
-        """
+        r"""
         INPUT:
             - `x` -- An integer.
         
@@ -604,7 +595,7 @@ class TrivialMonoid ( SageObject ) :
         raise TypeError( "Cannot convert %s into Trivial monoid." % (x,) )
     
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialMonoid
             sage: TrivialMonoid() == TrivialMonoid()    # indirect doctest
@@ -613,7 +604,7 @@ class TrivialMonoid ( SageObject ) :
         return cmp(type(self), type(other))
     
     def __iter__(self) :
-        """
+        r"""
         OUTPUT:
             A generator over integers.
         
@@ -628,7 +619,7 @@ class TrivialMonoid ( SageObject ) :
         raise StopIteration
     
     def _repr_(self) :
-        """
+        r"""
         OUTPUT:
             A string.
         
@@ -641,7 +632,7 @@ class TrivialMonoid ( SageObject ) :
         return "Trivial monoid"
     
     def _latex_(self) :
-        """
+        r"""
         OUTPUT:
             A string.
         
@@ -649,9 +640,9 @@ class TrivialMonoid ( SageObject ) :
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialMonoid
             sage: m = TrivialMonoid()
             sage: latex(m)    # indirect doctest
-            Trivial monoid
+            \text{Trivial monoid}
         """
-        return "Trivial monoid"
+        return r"\text{Trivial monoid}"
 
 #===============================================================================
 # TrivialCharacterMonoid
@@ -660,7 +651,7 @@ class TrivialMonoid ( SageObject ) :
 _trivial_evaluations = dict()
 
 def TrivialCharacterMonoid(G, K) :
-    """
+    r"""
     Return the monoid of characters with codomain `K` with one element.
     
     INPUT:
@@ -670,6 +661,7 @@ def TrivialCharacterMonoid(G, K) :
         An instance of :class:`~.CharacterMonoid_class`.
     
     TESTS::
+        sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialCharacterMonoid
         sage: h = TrivialCharacterMonoid("ZZ", QQ)
         sage: h
         Character monoid over Trivial monoid
@@ -691,13 +683,13 @@ def TrivialCharacterMonoid(G, K) :
 #===============================================================================
 
 class TrivialRepresentation ( SageObject ) :
-    """
+    r"""
     A trivial representation over a group `G` with codomain `K` occurring as a representation for
     :class:`~fourier_expansion_framework.monoidpowerseries.EquivariantMonoidPowerSeriesAmbient_abstract`.
     """
     
     def __init__(self, G, K) :
-        """
+        r"""
         INPUT:
             - `G`    -- Arbitrary type; A group or representative of a group.
             - `K`    -- A module or ring; The codomain of the representation.
@@ -716,7 +708,7 @@ class TrivialRepresentation ( SageObject ) :
         self.__K = K
         
     def base_ring(self) :
-        """
+        r"""
         The base ring of the representation, commuting with the action.
         
         OUTPUT:
@@ -731,13 +723,13 @@ class TrivialRepresentation ( SageObject ) :
             sage: rep.base_ring()
             Integer Ring
         """
-        if is_Ring(self.__K) :
+        if self.__K in Rings() :
             return self.__K
         else :
             return self.__K.base_ring()
     
     def codomain(self) :
-        """
+        r"""
         The codomain of the representation.
         
         OUTPUT:
@@ -751,8 +743,31 @@ class TrivialRepresentation ( SageObject ) :
         """
         return self.__K
     
-    def base_extend(self, L) :
+    def from_module(self, R) :
+        r"""
+        Construct a representation of the same type with codomain `R`.
+        
+        INPUT:
+        
+        - `R`        -- A module that the representation can be restricted or
+                        extended to.
+        
+        OUTPUT:
+        
+        - An instance of :class:`~.TrivialRepresentation`.
+        
+        EXAMPLES::
+        
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialRepresentation
+            sage: rep = TrivialRepresentation("ZZ", FreeModule(ZZ, 3))
+            sage: rep2 = rep.from_module(FreeModule(QQ, 2))
+            sage: rep2.codomain()
+            Vector space of dimension 2 over Rational Field
         """
+        return TrivialRepresentation( self.__G, R )
+    
+    def base_extend(self, L) :
+        r"""
         Extend the representation's codomain by `L`.
         
         INPUT:
@@ -771,11 +786,23 @@ class TrivialRepresentation ( SageObject ) :
             Traceback (most recent call last):
             ...
             TypeError: Base extension of self (over 'Rational Field') to ring 'Finite Field of size 3' not defined.
+            sage: rep = TrivialRepresentation("ZZ", ZZ)
+            sage: repQQ = rep.base_extend(QQ)
+            sage: repQQ.codomain()
+            Rational Field
+            sage: repQQ.base_extend(GF(3))
+            Traceback (most recent call last):
+            ...
+            AssertionError
         """
-        return TrivialRepresentation( self.__G, self.__K.base_extend(L) )
+        if self.__K in Rings() :
+            assert L.has_coerce_map_from(self.__K)
+            return TrivialRepresentation( self.__G, L )
+        else :
+            return TrivialRepresentation( self.__G, self.__K.base_extend(L) )
         
     def extends(self, other) :
-        """
+        r"""
         Wheter ``self`` is an extension of ``other``.
         
         INPUT:
@@ -803,7 +830,7 @@ class TrivialRepresentation ( SageObject ) :
         return self.__K.has_coerce_map_from(other.__K)
 
     def group(self) :
-        """
+        r"""
         The group that acts.
         
         OUTPUT:
@@ -818,7 +845,7 @@ class TrivialRepresentation ( SageObject ) :
         return self.__G
     
     def _apply_function(self) :
-        """
+        r"""
         A function that maps a group element and an element of the codomain to its image.
         
         OUTPUT:
@@ -833,7 +860,7 @@ class TrivialRepresentation ( SageObject ) :
         return self.apply
     
     def apply(self, g, a) :
-        """
+        r"""
         Return the image of `a` under the transformation `g`.
         
         INPUT:
@@ -852,7 +879,7 @@ class TrivialRepresentation ( SageObject ) :
         return a
     
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialRepresentation
             sage: rep1 = TrivialRepresentation("ZZ", QQ)
@@ -872,7 +899,7 @@ class TrivialRepresentation ( SageObject ) :
         return c
     
     def __hash__(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialRepresentation
             sage: rep = TrivialRepresentation("ZZ", QQ)
@@ -883,7 +910,7 @@ class TrivialRepresentation ( SageObject ) :
         return xor(hash(self.__G), hash(self.__K))
 
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialRepresentation
             sage: rep = TrivialRepresentation("ZZ", QQ)
@@ -893,27 +920,27 @@ class TrivialRepresentation ( SageObject ) :
         return "Trivial representation of %s on %s" % (self.__G, self.__K)
     
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialRepresentation
             sage: rep = TrivialRepresentation("ZZ", QQ)
             sage: latex(rep)
-            Trivial representation of \texttt{ZZ} on \Bold{Q}
+            \text{Trivial representation of $\verb|ZZ|$ on $\Bold{Q}$}
         """
-        return "Trivial representation of %s on %s" % (latex(self.__G), latex(self.__K))
+        return r"\text{Trivial representation of $%s$ on $%s$}" % (latex(self.__G), latex(self.__K))
 
 #===============================================================================
 # NNMonoid
 #===============================================================================
 
 class NNMonoid( SageObject ) :
-    """
+    r"""
     Monoid of all natural numbers with zero as is can occure as an arguement of
     :class:`~fourier_expansion_framework.monoidpowerseries.MonoidPowerSeriesAmbient_abstract`.
     """
     
     def __init__(self, reduced = True) :
-        """
+        r"""
         INPUT:
             - ``reduce``    -- A boolean (default: True); Wheter ``self`` is equipped with an action
                                or not.
@@ -928,7 +955,7 @@ class NNMonoid( SageObject ) :
         self.__reduced = reduced
 
     def ngens(self) :
-        """
+        r"""
         OUTPUT:
             An integer.
         
@@ -941,7 +968,7 @@ class NNMonoid( SageObject ) :
         return 1
     
     def gen(self, i = 0) :
-        """
+        r"""
         OUTPUT:
             An integer.
         
@@ -962,7 +989,7 @@ class NNMonoid( SageObject ) :
         raise ValueError( "Generator not defined." )
     
     def gens(self) :
-        """
+        r"""
         OUTPUT:
             A tuple of integers.
         
@@ -975,7 +1002,7 @@ class NNMonoid( SageObject ) :
         return tuple([self.gen(i) for i in xrange(self.ngens())])
 
     def is_commutative(self) :
-        """
+        r"""
         Whether the monoid is commutative or not.
         
         OUTPUT:
@@ -990,7 +1017,7 @@ class NNMonoid( SageObject ) :
         return True
     
     def monoid(self) :
-        """
+        r"""
         If ``self`` respects the action of the trivial group return the underlying
         monoid without this action. Otherwise return a copy of ``self``.
 
@@ -1011,7 +1038,7 @@ class NNMonoid( SageObject ) :
         return NNMonoid(False) 
 
     def group(self) :
-        """
+        r"""
         If ``self`` respects the action of a group return representative.
         
         OUTPUT:
@@ -1034,7 +1061,7 @@ class NNMonoid( SageObject ) :
             raise ArithmeticError( "Monoid is not equipped with a group action.")
 
     def is_monoid_action(self) :
-        """
+        r"""
         In case ``self`` respects the action of a group, decide whether this action is a monoid action
         on the underlying monoid.
 
@@ -1058,7 +1085,7 @@ class NNMonoid( SageObject ) :
             raise ArithmeticError( "Monoid is not equipped with a group action.")
     
     def filter(self, bound) :
-        """
+        r"""
         Return a filter with given bound associated to this monoid.
         
         INPUT:
@@ -1083,7 +1110,7 @@ class NNMonoid( SageObject ) :
         return NNFilter(bound, self.__reduced)
 
     def filter_all(self) :
-        """
+        r"""
         Return the filter associated to this monoid which contains all elements.
         
         OUTPUT:
@@ -1104,7 +1131,7 @@ class NNMonoid( SageObject ) :
         return NNFilter(infinity, self.__reduced)
     
     def zero_filter(self) :
-        """
+        r"""
         Return the filter associated to this monoid which contains no elements.
         
         OUTPUT:
@@ -1125,7 +1152,7 @@ class NNMonoid( SageObject ) :
         return NNFilter(0, self.__reduced)         
 
     def minimal_composition_filter(self, ls, rs) :
-        """
+        r"""
         Given two lists `ls` and `rs` of natural numbers return a filter that contains
         all the sums `l + r` of elements `l \in ls,\, r \in rs`.
         
@@ -1162,7 +1189,7 @@ class NNMonoid( SageObject ) :
         return NNFilter(max(0, max(ls) + max(rs) + 1), self.__reduced)
 
     def _reduction_function(self) :
-        """
+        r"""
         In case ``self`` respects the action of a group, return the
         reduction funtion for elements of this monoid.
         
@@ -1189,7 +1216,7 @@ class NNMonoid( SageObject ) :
             raise ArithmeticError( "Monoid is not equipped with a group action." )
 
     def reduce(self, s) :
-        """
+        r"""
         Reduce a natural number with respect to the trivial groups.
         
         INPUT:
@@ -1207,7 +1234,7 @@ class NNMonoid( SageObject ) :
         return (s, 1)
   
     def decompositions(self, s) :
-        """
+        r"""
         Decompose a natural number `s` in to a sum of two.
         
         INPUT:
@@ -1228,7 +1255,7 @@ class NNMonoid( SageObject ) :
         raise StopIteration
     
     def zero_element(self) :
-        """
+        r"""
         The zero element of this monoid.
         
         OUTPUT:
@@ -1243,7 +1270,7 @@ class NNMonoid( SageObject ) :
         return 0
 
     def __contains__(self, x) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
             sage: m = NNMonoid()
@@ -1257,7 +1284,7 @@ class NNMonoid( SageObject ) :
         return isinstance(x, (int, Integer)) and x >= 0
 
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
             sage: m = NNMonoid()
@@ -1273,7 +1300,7 @@ class NNMonoid( SageObject ) :
         return c
     
     def __hash__(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
             sage: hash(NNMonoid())
@@ -1284,7 +1311,7 @@ class NNMonoid( SageObject ) :
         return hash(self.__reduced)
     
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
             sage: repr(NNMonoid())
@@ -1298,30 +1325,30 @@ class NNMonoid( SageObject ) :
             return "NN with action"
             
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
             sage: latex(NNMonoid())
-            $\NN$ with action
+            \Bold{N}\text{ with action}
             sage: latex(NNMonoid(False))
-            $\NN$
+            \Bold{N}
         """
         if not self.__reduced :
-            return "$\NN$"
+            return r"\Bold{N}"
         else :
-            return "$\NN$ with action"
+            return r"\Bold{N}\text{ with action}"
 
 #===============================================================================
 # NNFilter
 #===============================================================================
 
 class NNFilter ( SageObject ) :
-    """
+    r"""
     A filter for the monoid of natrual numbers bounding elements by their value.
     """
     
     def __init__(self, bound, reduced = True) :
-        """
+        r"""
         INPUT:
             - ``bound``   -- An integer; A bound for the natural numbers.
             - ``reduced`` -- A boolean (default: True); If True the action of the trivial
@@ -1331,7 +1358,7 @@ class NNFilter ( SageObject ) :
             An instance of :class:`~.NNFilter`.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNFilter
             sage: f = NNFilter(3) # indirect doctest
             sage: f = NNFilter(7, False) # indirect doctest
         """
@@ -1342,14 +1369,14 @@ class NNFilter ( SageObject ) :
         self.__reduced = reduced
 
     def is_infinite(self) :
-        """
+        r"""
         Whether the filter contains infinitely many elements.
         
         OUTPUT:
             A boolean.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNFilter
             sage: NNFilter(3).is_infinite()
             False
             sage: NNFilter(infinity).is_infinite()
@@ -1358,14 +1385,14 @@ class NNFilter ( SageObject ) :
         return self.__bound is infinity
 
     def is_all(self) :
-        """
+        r"""
         Whether the filter contains all elements of the associated monoid.
         
         OUTPUT:
             A boolean.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNFilter
             sage: NNFilter(3).is_all()
             False
             sage: NNFilter(infinity).is_all()
@@ -1374,28 +1401,28 @@ class NNFilter ( SageObject ) :
         return self.is_infinite()
 
     def index(self) :
-        """
+        r"""
         Return the bound for this filter.
         
         OUTPUT:
             An integer.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNFilter
             sage: NNFilter(3).index()
             3
         """
         return self.__bound
     
     def is_reduced(self) :
-        """
+        r"""
         Whether the filter respects the action of a group.
         
         OUTPUT:
             A boolean.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNFilter
             sage: NNFilter(3).is_reduced()
             True
             sage: NNFilter(7, False).is_reduced()
@@ -1404,9 +1431,9 @@ class NNFilter ( SageObject ) :
         return self.__reduced
     
     def __contains__(self, n) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNFilter
             sage: f = NNFilter(10)
             sage: 3 in f # indirect doctest
             True
@@ -1421,12 +1448,12 @@ class NNFilter ( SageObject ) :
         return n < self.__bound
     
     def __iter__(self) :
-        """
+        r"""
         OUTPUT:
             A generator over integers.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNFilter
             sage: list(NNFilter(4)) == range(4) # indirect doctest
             True
             sage: list(NNFilter(infinity))
@@ -1443,9 +1470,9 @@ class NNFilter ( SageObject ) :
         raise StopIteration
     
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNFilter
             sage: NNFilter(4) == NNFilter(4) # indirect doctest
             True
             sage: NNFilter(4) == NNFilter(5) # indirect doctest
@@ -1462,9 +1489,9 @@ class NNFilter ( SageObject ) :
         return c
 
     def __hash__(self) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNFilter
             sage: hash(NNFilter(4)) # indirect doctest
             21
             sage: hash(NNFilter(7, False)) # indirect doctest
@@ -1473,9 +1500,9 @@ class NNFilter ( SageObject ) :
         return hash(self.__bound) + 17 * hash(self.__reduced)
                    
     def _repr_(self) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNFilter
             sage: repr(NNFilter(3))
             'Filtered NN with action up to 3'
             sage: repr(NNFilter(4, False))
@@ -1487,15 +1514,15 @@ class NNFilter ( SageObject ) :
             return "Filtered NN up to %s" % self.__bound
     
     def _latex_(self) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNFilter
             sage: latex(NNFilter(3))
-            Filtered $\NN$ with action up to $3$
+            \text{Filtered $\Bold{N}$ with action up to $3$}
             sage: latex(NNFilter(4, False))
-            Filtered $\NN$ up to $4$
+            \text{Filtered $\Bold{N}$ up to $4$}
         """
         if self.__reduced :
-            return "Filtered $\NN$ with action up to $%s$" % latex(self.__bound)
+            return r"\text{Filtered $\Bold{N}$ with action up to $%s$}" % latex(self.__bound)
         else :
-            return "Filtered $\NN$ up to $%s$" % latex(self.__bound)
+            return r"\text{Filtered $\Bold{N}$ up to $%s$}" % latex(self.__bound)

--- a/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_element.py
+++ b/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_element.py
@@ -37,7 +37,7 @@ from sage.rings.ring import Ring
 #===============================================================================
 
 def MonoidPowerSeries( parent, coefficients, precision, cleanup_coefficients = False) :
-    """
+    r"""
     Create a monoid power series within a given parent.
     
     INPUT:
@@ -77,13 +77,13 @@ def MonoidPowerSeries( parent, coefficients, precision, cleanup_coefficients = F
 #===============================================================================
 
 class MonoidPowerSeries_abstract :
-    """
+    r"""
     An element of the monoid power series ring or module up to
     given precision.
     """
     
     def __init__(self, parent, precision) :
-        """
+        r"""
         INPUT:
             - ``parent``       -- An instance of :class:~`fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient.MonoidPowerSeriesAmbient_abstract`.
             - ``precision``    -- A filter associated to the parent's monoid.
@@ -98,7 +98,7 @@ class MonoidPowerSeries_abstract :
         self.__precision = parent.monoid().filter(precision)
         
     def precision(self) :
-        """
+        r"""
         The series' precision.
         
         OUTPUT:
@@ -115,7 +115,7 @@ class MonoidPowerSeries_abstract :
         return self.__precision
 
     def _set_precision(self, precision) :
-        """
+        r"""
         Set the series' precision.
         
         INPUT:
@@ -138,7 +138,7 @@ class MonoidPowerSeries_abstract :
         self.__precision = self.parent().monoid().filter(precision)
 
     def _bounding_precision(self) :
-        """
+        r"""
         If ``self.precision()`` is an infinite filter,  return a filter
         which contains all non zero coefficients of this series. Otherwise,
         return ``self.precision()``
@@ -165,7 +165,7 @@ class MonoidPowerSeries_abstract :
                                                                  [self.parent().monoid().zero_element()] )
 
     def coefficients(self) :
-        """
+        r"""
         The coefficients of ``self``.
         
         OUTPUT:
@@ -185,7 +185,7 @@ class MonoidPowerSeries_abstract :
         raise NotImplementedError
     
     def _truncate_in_place(self, precision) :
-        """
+        r"""
         Truncate ``self`` modifying the coefficient dictionary directly.
         
         INPUT:
@@ -208,7 +208,7 @@ class MonoidPowerSeries_abstract :
         raise NotImplementedError
     
     def truncate(self, precision) :
-        """
+        r"""
         Truncate a copy of ``self``.
 
         INPUT:
@@ -231,7 +231,7 @@ class MonoidPowerSeries_abstract :
         raise NotImplementedError
     
     def _add_(left, right) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -258,7 +258,7 @@ class MonoidPowerSeries_abstract :
         return MonoidPowerSeries(left.parent(), d, prec)
     
     def _mul_(left, right, switch_factors = False) :
-        """
+        r"""
         NOTE:
             This function has to accept algebra and module elements and will
             also compute the action of the base ring (which might be a monoid power series)
@@ -300,7 +300,7 @@ class MonoidPowerSeries_abstract :
         return MonoidPowerSeries(left.parent(), d, prec)
     
     def _lmul_(self, c) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -333,7 +333,7 @@ class MonoidPowerSeries_abstract :
             return MonoidPowerSeries(self.parent(), d, self.precision())
     
     def _rmul_(self, c) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -367,7 +367,7 @@ class MonoidPowerSeries_abstract :
             return MonoidPowerSeries(self.parent(), d, self.precision())
 
     def __contains__(self, k) :
-        """
+        r"""
         Check whether `k` is below the series' precision.
         
         INPUT:
@@ -389,7 +389,7 @@ class MonoidPowerSeries_abstract :
         return k in self.precision()
 
     def __getitem__(self, s) :
-        """
+        r"""
         Return the `k`-th coefficient if it below the series' precision.
         
         INPUT:
@@ -411,7 +411,7 @@ class MonoidPowerSeries_abstract :
         raise NotImplementedError
         
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -444,7 +444,7 @@ class MonoidPowerSeries_abstract :
         return 0
 
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -456,28 +456,28 @@ class MonoidPowerSeries_abstract :
         return "Monoid power series in %s" % self.parent()
     
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: mps = MonoidPowerSeriesRing(QQ, NNMonoid(False))
             sage: latex(mps.one_element()) # indirect doctest
-            Monoid power series in %sRing of monoid power series over $\NN$
+            \text{Monoid power series in } \text{Ring of monoid power series over }\Bold{N}
         """
-        return "Monoid power series in %s" + latex(self.parent())
+        return r"\text{Monoid power series in }" + latex(self.parent())
 
 #===============================================================================
 # MonoidPowerSeries_abstract_nonlazy
 #===============================================================================
 
 class MonoidPowerSeries_abstract_nonlazy (MonoidPowerSeries_abstract) :
-    """
+    r"""
     A abstract implementation of monoid power series that store their coefficients.
     """
         
     def __init__(self, parent, coefficients, precision, cleanup_coefficients) :
-        """
+        r"""
         INPUT:
             - ``parent``       -- An instance of :class:~`fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient.MonoidPowerSeriesAmbient_abstract`.
             - ``coefficients`` -- A dictionary with keys in the parent's monoid and values
@@ -501,7 +501,7 @@ class MonoidPowerSeries_abstract_nonlazy (MonoidPowerSeries_abstract) :
         self.__coefficients = coefficients
     
     def coefficients(self) :
-        """
+        r"""
         The coefficients of ``self``.
         
         OUTPUT:
@@ -523,7 +523,7 @@ class MonoidPowerSeries_abstract_nonlazy (MonoidPowerSeries_abstract) :
         return self.__coefficients
     
     def _cleanup_coefficients(self, coefficients = None, in_place = True) :
-        """
+        r"""
         Remove zero entries and entries not below ``self.precision()`` from a coefficient dictionary.
         
         INPUT:
@@ -578,7 +578,7 @@ class MonoidPowerSeries_abstract_nonlazy (MonoidPowerSeries_abstract) :
             return ncoefficients
 
     def _truncate_in_place(self, precision) :
-        """
+        r"""
         Truncate ``self`` modifying the coefficient dictionary directly.
         
         INPUT:
@@ -614,7 +614,7 @@ class MonoidPowerSeries_abstract_nonlazy (MonoidPowerSeries_abstract) :
         self._set_precision(nprec)
     
     def truncate(self, precision) :
-        """
+        r"""
         Truncate a copy of ``self``.
         
         INPUT:
@@ -641,7 +641,7 @@ class MonoidPowerSeries_abstract_nonlazy (MonoidPowerSeries_abstract) :
         return MonoidPowerSeries( self.parent(), ncoefficients, nprec, cleanup_coefficients = True )
     
     def __getitem__(self, s) :
-        """
+        r"""
         Return the `k`-th coefficient if it below the series' precision.
         
         INPUT:
@@ -668,12 +668,12 @@ class MonoidPowerSeries_abstract_nonlazy (MonoidPowerSeries_abstract) :
 #===============================================================================
 
 class MonoidPowerSeries_moduleelement ( MonoidPowerSeries_abstract_nonlazy, ModuleElement ) :
-    """
+    r"""
     An element of a module of monoid power series.
     """
 
     def __init__(self, parent, coefficients, precision, cleanup_coefficients) :
-        """
+        r"""
         INPUT:
             - ``parent``       -- An instance of :class:~`fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient.MonoidPowerSeriesAmbient_abstract`.
             - ``coefficients`` -- A dictionary with keys in the parent's monoid and values
@@ -697,12 +697,12 @@ class MonoidPowerSeries_moduleelement ( MonoidPowerSeries_abstract_nonlazy, Modu
 #===============================================================================
 
 class MonoidPowerSeries_algebraelement ( MonoidPowerSeries_abstract_nonlazy, AlgebraElement ) :
-    """
+    r"""
     An element of a algebra of monoid power series.
     """
     
     def __init__(self, parent, coefficients, precision, cleanup_coefficients) :
-        """
+        r"""
         INPUT:
             - ``parent``       -- An instance of :class:~`fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient.MonoidPowerSeriesAmbient_abstract`.
             - ``coefficients`` -- A dictionary with keys in the parent's monoid and values
@@ -727,7 +727,7 @@ class MonoidPowerSeries_algebraelement ( MonoidPowerSeries_abstract_nonlazy, Alg
 
 def EquivariantMonoidPowerSeries( parent, coefficients, precision, symmetrise = False,
                                   cleanup_coefficients = False) :
-    """
+    r"""
     Create an equivariant monoid power series within a given parent.
     
     INPUT:
@@ -772,13 +772,13 @@ def EquivariantMonoidPowerSeries( parent, coefficients, precision, symmetrise = 
 #===============================================================================
 
 class EquivariantMonoidPowerSeries_abstract :
-    """
+    r"""
     An abstract element of an equivariant monoid power series ring up to
     given precision.
     """
     
     def __init__( self, parent, precision ) :
-        """
+        r"""
         INPUT:
             - ``parent``       -- A ring or module of equivariant monoid power series.
             - ``precision``    -- A filter for the parent's action.
@@ -793,7 +793,7 @@ class EquivariantMonoidPowerSeries_abstract :
         self.__precision = parent.action().filter(precision)
 
     def precision(self) :
-        """
+        r"""
         The series' precision.
         
         OUTPUT:
@@ -810,7 +810,7 @@ class EquivariantMonoidPowerSeries_abstract :
         return self.__precision
     
     def _set_precision(self, precision) :
-        """
+        r"""
         Set the series' precision.
     
         INPUT:
@@ -832,7 +832,7 @@ class EquivariantMonoidPowerSeries_abstract :
         self.__precision = self.parent().action().filter(precision)
 
     def non_zero_components(self) :
-        """
+        r"""
         Return all those characters  which are not guaranteed to have only
         vanishing coefficients associated to.
         
@@ -857,7 +857,7 @@ class EquivariantMonoidPowerSeries_abstract :
         return list(self.parent().characters())
     
     def _bounding_precision(self) :
-        """
+        r"""
         If ``self.precision()`` is an infinite filter,  return a filter
         which contains all non zero coefficients of this series. Otherwise,
         return ``self.precision()``
@@ -888,7 +888,7 @@ class EquivariantMonoidPowerSeries_abstract :
         return m
     
     def coefficients(self, force_characters = False) :
-        """
+        r"""
         The coefficients of ``self``. 
 
         INPUT:
@@ -917,7 +917,7 @@ class EquivariantMonoidPowerSeries_abstract :
         raise NotImplementedError
         
     def _truncate_in_place(self, precision) :
-        """
+        r"""
         Truncate ``self`` modifying the coefficient dictionary directly.
         
         INPUT:
@@ -941,7 +941,7 @@ class EquivariantMonoidPowerSeries_abstract :
         raise NotImplementedError
         
     def truncate(self, precision) :
-        """
+        r"""
         Truncate a copy of ``self``.
 
         INPUT:
@@ -964,7 +964,7 @@ class EquivariantMonoidPowerSeries_abstract :
         raise NotImplementedError
     
     def _add_(left, right) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -1009,7 +1009,7 @@ class EquivariantMonoidPowerSeries_abstract :
                 coefficients, prec)
     
     def _mul_(left, right, switch_factors = False) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -1070,7 +1070,7 @@ class EquivariantMonoidPowerSeries_abstract :
         return EquivariantMonoidPowerSeries( left.parent(), coefficients, prec )
 
     def _lmul_(self, c) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -1115,7 +1115,7 @@ class EquivariantMonoidPowerSeries_abstract :
                                                 coefficients, self.precision())
             
     def _rmul_(self, c) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -1160,7 +1160,7 @@ class EquivariantMonoidPowerSeries_abstract :
                                                 coefficients, self.precision())
 
     def __contains__(self, k) :
-        """
+        r"""
         Check whether an index or a pair of character and index
         is containted in the precision.
         
@@ -1187,7 +1187,7 @@ class EquivariantMonoidPowerSeries_abstract :
         return k in self.precision()
 
     def __getitem__(self, k) :
-        """
+        r"""
         Return the `k`-th coefficient if it below the series' precision. If no character is contained
         in the key ``self`` must have only one nonvanishing component.
         
@@ -1211,7 +1211,7 @@ class EquivariantMonoidPowerSeries_abstract :
         raise NotImplementedError
 
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -1261,7 +1261,7 @@ class EquivariantMonoidPowerSeries_abstract :
         return 0
 
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
@@ -1273,29 +1273,29 @@ class EquivariantMonoidPowerSeries_abstract :
         return "Equivariant monoid power series in %s" % (self.parent(),)
     
     def _latex_(self) :
-        """
+        r"""
         EXAMPLES:
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: emps = EquivariantMonoidPowerSeriesRing( NNMonoid(), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", QQ) )
             sage: latex( EquivariantMonoidPowerSeries(emps, {emps.characters().one_element() : { 1 : 1 }}, emps.action().zero_filter()) )
-            Equivariant monoid power series in Ring of equivariant monoid power series over $\NN$
+            \text{Equivariant monoid power series in }\text{Ring of equivariant monoid power series over }\Bold{N}
         """
-        return "Equivariant monoid power series in %s" % latex(self.parent())
+        return r"\text{Equivariant monoid power series in }%s" % latex(self.parent())
 
 #===============================================================================
 # EquivariantMonoidPowerSeries_abstract_nonlazy
 #===============================================================================
 
 class EquivariantMonoidPowerSeries_abstract_nonlazy ( EquivariantMonoidPowerSeries_abstract ) :
-    """
+    r"""
     A abstract implementation of equiavariant monoid power series that store their coefficients.
     """
     
     def __init__( self, parent, coefficients, precision, symmetrise,
                   cleanup_coefficients ) :
-        """
+        r"""
         INPUT:
             - ``parent``       -- A ring or module of equivariant monoid power series.
             - ``coefficients`` -- A dictionary with keys in the parent's monoid and values
@@ -1350,7 +1350,7 @@ class EquivariantMonoidPowerSeries_abstract_nonlazy ( EquivariantMonoidPowerSeri
             self.__coefficients = ncoefficients
 
     def non_zero_components(self) :
-        """
+        r"""
         Return all those characters  which are not guaranteed to have only
         vanishing coefficients associated to.
         
@@ -1377,7 +1377,7 @@ class EquivariantMonoidPowerSeries_abstract_nonlazy ( EquivariantMonoidPowerSeri
         return self.__coefficients.keys()
     
     def coefficients(self, force_characters = False) :
-        """
+        r"""
         The coefficients of ``self``. 
 
         INPUT:
@@ -1415,7 +1415,7 @@ class EquivariantMonoidPowerSeries_abstract_nonlazy ( EquivariantMonoidPowerSeri
             return self.__coefficients
 
     def _cleanup_coefficients(self, coefficients = None, in_place = True) :
-        """
+        r"""
         Remove zero entries and entries not below ``self.precision()`` from a coefficient dictionary.
         
         INPUT:
@@ -1483,7 +1483,7 @@ class EquivariantMonoidPowerSeries_abstract_nonlazy ( EquivariantMonoidPowerSeri
             return ncoefficients
 
     def _truncate_in_place(self, precision) :
-        """
+        r"""
         Truncate ``self`` modifying the coefficient dictionary directly.
 
         INPUT:
@@ -1520,7 +1520,7 @@ class EquivariantMonoidPowerSeries_abstract_nonlazy ( EquivariantMonoidPowerSeri
             self._set_precision(nprec)
     
     def truncate(self, precision) :
-        """
+        r"""
         Truncate a copy of ``self``.
 
         INPUT:
@@ -1550,7 +1550,7 @@ class EquivariantMonoidPowerSeries_abstract_nonlazy ( EquivariantMonoidPowerSeri
                  ncoefficients, nprec, cleanup_coefficients = True )
 
     def __getitem__(self, k) :
-        """
+        r"""
         Return the `k`-th coefficient if it below the series' precision. If no character is contained
         in the key ``self`` must have only one nonvanishing component.
         
@@ -1619,13 +1619,13 @@ class EquivariantMonoidPowerSeries_abstract_nonlazy ( EquivariantMonoidPowerSeri
 #===============================================================================
 
 class EquivariantMonoidPowerSeries_moduleelement ( EquivariantMonoidPowerSeries_abstract_nonlazy, ModuleElement ) :
-    """
+    r"""
     An element of a module of equivariant monoid power series.
     """
 
     def __init__(self, parent, coefficients, precision, symmetrise,
                  cleanup_coefficients ) :
-        """
+        r"""
         INPUT:
             - ``parent``       -- A ring or module of equivariant monoid power series.
             - ``coefficients`` -- A dictionary with keys in the parent's monoid and values
@@ -1652,13 +1652,13 @@ class EquivariantMonoidPowerSeries_moduleelement ( EquivariantMonoidPowerSeries_
 #===============================================================================
 
 class EquivariantMonoidPowerSeries_algebraelement ( EquivariantMonoidPowerSeries_abstract_nonlazy, AlgebraElement ) :
-    """
+    r"""
     An element of an algebra of equivariant monoid power series.
     """
 
     def __init__(self, parent, coefficients, precision, symmetrise,
                  cleanup_coefficients ) :
-        """
+        r"""
         INPUT:
             - ``parent``       -- A ring or module of equivariant monoid power series.
             - ``coefficients`` -- A dictionary with keys in the parent's monoid and values

--- a/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_functor.py
+++ b/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_functor.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Functor creating rings or modules of (equivariant) monoid power series. 
 
 AUTHOR :
@@ -24,17 +24,20 @@ AUTHOR :
 #
 #===============================================================================
 
+from sage.categories.commutative_additive_groups import CommutativeAdditiveGroups
 from sage.categories.rings import Rings
+from sage.categories.modules import Modules
 from sage.categories.morphism import Morphism
-from sage.categories.pushout import ConstructionFunctor
+from sage.categories.pushout import pushout, ConstructionFunctor
 from sage.rings.ring import Ring
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing
 
 #===============================================================================
-# MonoidPowerSeriesFunctor
+# MonoidPowerSeriesRingFunctor
 #===============================================================================
 
-class MonoidPowerSeriesFunctor ( ConstructionFunctor ) :
-    """
+class MonoidPowerSeriesRingFunctor ( ConstructionFunctor ) :
+    r"""
     Functor mapping a coefficient ring to a monoid power series ring
     over a given monoid.
     """
@@ -42,37 +45,37 @@ class MonoidPowerSeriesFunctor ( ConstructionFunctor ) :
     rank = 9
     
     def __init__(self, S) :
-        """
+        r"""
         INPUT:
             - `S` -- A monoid as in :class:`~from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids.NNMonoid`
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesRingFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
-            sage: F = MonoidPowerSeriesFunctor(NNMonoid(False))
+            sage: F = MonoidPowerSeriesRingFunctor(NNMonoid(False))
         """
         self.__S = S
         
         ConstructionFunctor.__init__(self, Rings(), Rings())
         
     def monoid(self) :
-        """
+        r"""
         Return the monoid associated to this functor.
         
         OUTPUT:
             A monoid as in :class:`~from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids.NNMonoid`.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesRingFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
-            sage: F = MonoidPowerSeriesFunctor(NNMonoid(False))
+            sage: F = MonoidPowerSeriesRingFunctor(NNMonoid(False))
             sage: F.monoid()
             NN
         """
         return self.__S
 
     def __call__(self, A) :
-        """
+        r"""
         Apply a ``self`` to a coefficient domain `A`.
         
         INPUT:
@@ -84,33 +87,26 @@ class MonoidPowerSeriesFunctor ( ConstructionFunctor ) :
             A ring if `A` is a ring, a module if `A` is a module.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesRingFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
-            sage: F = MonoidPowerSeriesFunctor(NNMonoid(False))
+            sage: F = MonoidPowerSeriesRingFunctor(NNMonoid(False))
             sage: mps = F(ZZ)
             sage: mps.monoid() == NNMonoid(False)
             True
             sage: mps.coefficient_domain()
             Integer Ring
-            sage: F(FreeModule(QQ, 3)).coefficient_domain()
-            Vector space of dimension 3 over Rational Field
         """
-        if isinstance(A, Ring) :
-            from monoidpowerseries_ring import MonoidPowerSeriesRing
+        from monoidpowerseries_ring import MonoidPowerSeriesRing
 
-            return MonoidPowerSeriesRing(A, self.__S)
-        else :
-            from monoidpowerseries_module import MonoidPowerSeriesModule
-            
-            return MonoidPowerSeriesModule(A, self.__S)
+        return MonoidPowerSeriesRing(A, self.__S)
         
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesRingFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
-            sage: F = MonoidPowerSeriesFunctor(NNMonoid(False))
-            sage: F == MonoidPowerSeriesFunctor(NNMonoid(False))
+            sage: F = MonoidPowerSeriesRingFunctor(NNMonoid(False))
+            sage: F == MonoidPowerSeriesRingFunctor(NNMonoid(False))
             True
         """
         c = cmp(type(self), type(other))
@@ -119,13 +115,104 @@ class MonoidPowerSeriesFunctor ( ConstructionFunctor ) :
             c = cmp(self.__S, other.__S)
             
         return c
-    
+
 #===============================================================================
-# EquivariantMonoidPowerSeriesFunctor
+# MonoidPowerSeriesModuleFunctor
 #===============================================================================
 
-class EquivariantMonoidPowerSeriesFunctor ( ConstructionFunctor ) :
+class MonoidPowerSeriesModuleFunctor ( ConstructionFunctor ) :
+    r"""
+    Functor mapping a coefficient module to a monoid power series module
+    over a given monoid.
     """
+    
+    rank = 9
+    
+    def __init__(self, B, S) :
+        r"""
+        INPUT:
+            - `B` -- A ring.
+            - `S` -- A monoid as in :class:`~from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids.NNMonoid`
+        
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesModuleFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: F = MonoidPowerSeriesModuleFunctor(ZZ, NNMonoid(False))
+        """
+        self.__S = S
+        
+        ConstructionFunctor.__init__(self, Modules(B), CommutativeAdditiveGroups())
+        
+    def monoid(self) :
+        r"""
+        Return the monoid associated to this functor.
+        
+        OUTPUT:
+            A monoid as in :class:`~from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids.NNMonoid`.
+        
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesModuleFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: F = MonoidPowerSeriesModuleFunctor(ZZ, NNMonoid(False))
+            sage: F.monoid()
+            NN
+        """
+        return self.__S
+
+    def __call__(self, A) :
+        r"""
+        Apply a ``self`` to a coefficient domain `A`.
+        
+        INPUT:
+            - `A` -- A ring or module. The domain of coefficients for
+                     a ring or module of monoid power series.
+        
+        OUTPUT:
+            An instance of :class:`~from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient.MonoidPowerSeriesAmbient_abstract`.
+            A ring if `A` is a ring, a module if `A` is a module.
+        
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesModuleFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: F = MonoidPowerSeriesModuleFunctor(ZZ, NNMonoid(False))
+            sage: mps = F(FreeModule(ZZ, 1))
+            sage: mps.monoid() == NNMonoid(False)
+            True
+            sage: mps.coefficient_domain()
+            Ambient free module of rank 1 over the principal ideal domain Integer Ring
+            sage: F(FreeModule(QQ, 3)).coefficient_domain()
+            Vector space of dimension 3 over Rational Field
+        """
+        from monoidpowerseries_module import MonoidPowerSeriesModule
+            
+        return MonoidPowerSeriesModule(A, self.__S)
+        
+    def __cmp__(self, other) :
+        r"""
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesModuleFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
+            sage: F = MonoidPowerSeriesModuleFunctor(ZZ, NNMonoid(False))
+            sage: F == MonoidPowerSeriesModuleFunctor(ZZ, NNMonoid(False))
+            True
+            sage: F == MonoidPowerSeriesModuleFunctor(QQ, NNMonoid(False))
+            False
+        """
+        c = cmp(type(self), type(other))
+        
+        if c == 0 :
+            c = cmp(self.domain().base_ring(), other.domain().base_ring())
+        if c == 0 :
+            c = cmp(self.__S, other.__S)
+            
+        return c
+    
+#===============================================================================
+# EquivariantMonoidPowerSeriesRingFunctor
+#===============================================================================
+
+class EquivariantMonoidPowerSeriesRingFunctor ( ConstructionFunctor ) :
+    r"""
     Functor mapping a coefficient domain to a equivariant monoid power series
     ring or module over a given monoid action with character and representation.
     The representation will be extended by scalars if the coefficient domain's
@@ -135,7 +222,7 @@ class EquivariantMonoidPowerSeriesFunctor ( ConstructionFunctor ) :
     rank = 9
     
     def __init__(self, O, C, R) :
-        """
+        r"""
         INPUT:
             - `O` -- An action of a group `G` on a monoid as implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.NNMonoid`.
             - `C` -- A monoid of charcters `G -> K` for a ring `K`. As implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.CharacterMonoid_class`.
@@ -143,29 +230,31 @@ class EquivariantMonoidPowerSeriesFunctor ( ConstructionFunctor ) :
                      As implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.TrivialRepresentation`.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesRingFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
-            sage: F = EquivariantMonoidPowerSeriesFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: F = EquivariantMonoidPowerSeriesRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
         """
         if O.group() != C.group() :
             raise ValueError( "The action on S and the characters must have the same group" )
         if R.base_ring() != C.codomain() :
-            if C.codomain().has_coerce_map_from(R.base_ring()) :
-                pass
-            elif R.base_ring().has_coerce_map_from(C.codomain()) :
+#            if C.codomain().has_coerce_map_from(R.base_ring()) :
+#                pass
+#            el
+            if R.base_ring().has_coerce_map_from(C.codomain()) :
                 pass
             else :
                 raise ValueError( "character codomain and representation base ring must be coercible" )
+        if not O.is_monoid_action() :
+            raise ValueError( "monoid structure must be compatible with group action" )
         
         self.__O = O
         self.__C = C
         self.__R = R
         
-        ## TODO: replace Rings by an suitable category
         ConstructionFunctor.__init__(self, Rings(), Rings())
 
     def __call__(self, K) :
-        """
+        r"""
         Apply a ``self`` to a coefficient domain `A`.
         
         INPUT:
@@ -177,38 +266,33 @@ class EquivariantMonoidPowerSeriesFunctor ( ConstructionFunctor ) :
             A ring if the representation's extension by `A` is a ring, a module if this extension is a module.
             
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesRingFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
-            sage: F = EquivariantMonoidPowerSeriesFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: F = EquivariantMonoidPowerSeriesRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: emps = F(QQ)
             sage: emps.action() == NNMonoid()
             True
             sage: emps.characters()
             Character monoid over Trivial monoid
-            sage: F = EquivariantMonoidPowerSeriesFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 3)))
-            sage: emps = F(QQ)
-            sage: emps.coefficient_domain()
-            Vector space of dimension 3 over Rational Field
             """
-        R = self.__R.base_extend(K)
-        if self.__O.is_monoid_action() and isinstance(R.codomain(), Ring) :
-            from monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing
-
-            return EquivariantMonoidPowerSeriesRing( self.__O, self.__C, R )
+        if not self.__R.base_ring().has_coerce_map_from(K) : 
+            R = self.__R.base_extend( pushout(self.__R.base_ring(), K) )
         else :
-            from monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
+            R = self.__R
+        
+        from monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing
 
-            return EquivariantMonoidPowerSeriesModule( self.__O, self.__C, R )
+        return EquivariantMonoidPowerSeriesRing( self.__O, self.__C, R )
 
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesRingFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
-            sage: F = EquivariantMonoidPowerSeriesFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
-            sage: F == EquivariantMonoidPowerSeriesFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: F = EquivariantMonoidPowerSeriesRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: F == EquivariantMonoidPowerSeriesRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             True
-            sage: F == EquivariantMonoidPowerSeriesFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(QQ, 3)))
+            sage: F == EquivariantMonoidPowerSeriesRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(QQ, 3)))
             False
         """
         c = cmp(type(self), type(other))
@@ -222,7 +306,7 @@ class EquivariantMonoidPowerSeriesFunctor ( ConstructionFunctor ) :
         return c
     
     def expand(self) :
-        """
+        r"""
         An equivariant monoid power series can be constructed by first
         constructing a monoid power series and then symmetrising it with
         respect to the group action.
@@ -231,25 +315,25 @@ class EquivariantMonoidPowerSeriesFunctor ( ConstructionFunctor ) :
             A list of functors.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesRingFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
-            sage: F = EquivariantMonoidPowerSeriesFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: F = EquivariantMonoidPowerSeriesRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
             sage: F.expand()
-            [MonoidPowerSeriesSymmetrisationFunctor, MonoidPowerSeriesFunctor]
+            [MonoidPowerSeriesSymmetrisationRingFunctor, MonoidPowerSeriesRingFunctor]
         """
-        return [ MonoidPowerSeriesSymmetrisationFunctor(self.__O, self.__C, self.__R),
-                 MonoidPowerSeriesFunctor(self.__O.monoid()) ]
+        return [ MonoidPowerSeriesSymmetrisationRingFunctor(self.__O, self.__C, self.__R),
+                 MonoidPowerSeriesRingFunctor(self.__O.monoid()) ]
         
     def merge(self, other) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesRingFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
-            sage: F = EquivariantMonoidPowerSeriesFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
-            sage: G = EquivariantMonoidPowerSeriesFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", QQ))
+            sage: F = EquivariantMonoidPowerSeriesRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: G = EquivariantMonoidPowerSeriesRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", QQ))
             sage: F.merge(G) == G
             True
-            sage: G = EquivariantMonoidPowerSeriesFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 3)))
+            sage: G = EquivariantMonoidPowerSeriesRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 3)))
             sage: F.merge(G) is None
             True
         """
@@ -267,21 +351,23 @@ class EquivariantMonoidPowerSeriesFunctor ( ConstructionFunctor ) :
                 return None
         
         return None
-    
+
 #===============================================================================
-# MonoidPowerSeriesSymmetrisationFunctor
+# EquivariantMonoidPowerSeriesFunctor
 #===============================================================================
 
-class MonoidPowerSeriesSymmetrisationFunctor ( ConstructionFunctor) :
-    """
-    A functor mapping rings or modules of monoid power series
-    to a the an equivariant power series via symmetrisation.
+class EquivariantMonoidPowerSeriesModuleFunctor ( ConstructionFunctor ) :
+    r"""
+    Functor mapping a coefficient domain to a equivariant monoid power series
+    ring or module over a given monoid action with character and representation.
+    The representation will be extended by scalars if the coefficient domain's
+    base ring is to big.
     """
     
     rank = 9
     
     def __init__(self, O, C, R) :
-        """
+        r"""
         INPUT:
             - `O` -- An action of a group `G` on a monoid as implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.NNMonoid`.
             - `C` -- A monoid of charcters `G -> K` for a ring `K`. As implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.CharacterMonoid_class`.
@@ -289,9 +375,281 @@ class MonoidPowerSeriesSymmetrisationFunctor ( ConstructionFunctor) :
                      As implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.TrivialRepresentation`.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesModuleFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
-            sage: F = MonoidPowerSeriesSymmetrisationFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: F = EquivariantMonoidPowerSeriesModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+        """
+        if O.group() != C.group() :
+            raise ValueError( "The action on S and the characters must have the same group" )
+        if R.base_ring() != C.codomain() :
+#            if C.codomain().has_coerce_map_from(R.base_ring()) :
+#                pass
+#            el
+            if R.base_ring().has_coerce_map_from(C.codomain()) :
+                pass
+            else :
+                raise ValueError( "character codomain and representation base ring must be coercible" )
+        
+        self.__O = O
+        self.__C = C
+        self.__R = R
+        
+        ConstructionFunctor.__init__(self, Modules(R.base_ring()), CommutativeAdditiveGroups())
+
+    def __call__(self, K) :
+        r"""
+        Apply a ``self`` to a coefficient domain `A`.
+        
+        INPUT:
+            - `A` -- A ring or module. The domain of coefficients for
+                     a ring or module of equivariant monoid power series.
+        
+        OUTPUT:
+            An instance of :class:`~from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient.EquivariantMonoidPowerSeriesAmbient_abstract`.
+            A ring if the representation's extension by `A` is a ring, a module if this extension is a module.
+            
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesModuleFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
+            sage: F = EquivariantMonoidPowerSeriesModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 1)))
+            sage: emps = F(QQ)
+            sage: emps.action() == NNMonoid()
+            True
+            sage: emps.characters()
+            Character monoid over Trivial monoid
+            sage: F = EquivariantMonoidPowerSeriesModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 3)))
+            sage: emps = F(QQ)
+            sage: emps.coefficient_domain()
+            Vector space of dimension 3 over Rational Field
+            """
+        if not self.__R.base_ring().has_coerce_map_from(K) : 
+            R = self.__R.base_extend( pushout(self.__R.base_ring(), K) )
+        else :
+            R = self.__R
+        
+        from monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
+
+        return EquivariantMonoidPowerSeriesModule( self.__O, self.__C, R )
+
+    def __cmp__(self, other) :
+        r"""
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesModuleFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
+            sage: F = EquivariantMonoidPowerSeriesModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 1)))
+            sage: F == EquivariantMonoidPowerSeriesModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 1)))
+            True
+            sage: F == EquivariantMonoidPowerSeriesModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(QQ, 3)))
+            False
+        """
+        c = cmp(type(self), type(other))
+        if c == 0 :
+            c = cmp(self.__R, other.__R)
+        if c == 0 :
+            c = cmp(self.__O, other.__O)
+        if c == 0 :
+            c = cmp(self.__C, other.__C)
+        
+        return c
+    
+    def expand(self) :
+        r"""
+        An equivariant monoid power series can be constructed by first
+        constructing a monoid power series and then symmetrising it with
+        respect to the group action.
+        
+        OUTPUT:
+            A list of functors.
+        
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesModuleFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
+            sage: F = EquivariantMonoidPowerSeriesModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 1)))
+            sage: F.expand()
+            [MonoidPowerSeriesSymmetrisationModuleFunctor, MonoidPowerSeriesModuleFunctor]
+        """
+        return [ MonoidPowerSeriesSymmetrisationModuleFunctor(self.__O, self.__C, self.__R),
+                 MonoidPowerSeriesModuleFunctor(self.domain().base_ring(), self.__O.monoid()) ]
+        
+    def merge(self, other) :
+        r"""
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesModuleFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
+            sage: F = EquivariantMonoidPowerSeriesModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 1)))
+            sage: G = EquivariantMonoidPowerSeriesModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(QQ, 1)))
+            sage: F.merge(G) == G
+            True
+            sage: G = EquivariantMonoidPowerSeriesModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 3)))
+            sage: F.merge(G) is None
+            True
+        """
+        if self == other :
+            return self
+        elif type(self) == type(other) and \
+           self.__O == self.__O and \
+           self.__C == self.__C :
+            try :
+                if self.__R.extends(other.__R) :
+                    return self
+                elif other.__R.extends(self.__R) :
+                    return other
+            except AttributeError :
+                return None
+        
+        return None
+
+#===============================================================================
+# MonoidPowerSeriesSymmetrisationRingFunctor
+#===============================================================================
+
+class MonoidPowerSeriesSymmetrisationRingFunctor ( ConstructionFunctor) :
+    r"""
+    A functor mapping rings or modules of monoid power series
+    to a the an equivariant power series via symmetrisation.
+    """
+    
+    rank = 9
+    
+    def __init__(self, O, C, R) :
+        r"""
+        INPUT:
+            - `O` -- An action of a group `G` on a monoid as implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.NNMonoid`.
+            - `C` -- A monoid of charcters `G -> K` for a ring `K`. As implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.CharacterMonoid_class`.
+            - `R` -- A representation of `G` on some `K`-algebra or module `A`.
+                     As implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.TrivialRepresentation`.
+        
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationRingFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
+            sage: F = MonoidPowerSeriesSymmetrisationRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+        """
+        if O.group() != C.group() :
+            raise ValueError( "The action on S and the characters must have the same group" )
+        if R.base_ring() != C.codomain() :
+#            if C.codomain().has_coerce_map_from(R.base_ring()) :
+#                pass
+#            el
+            if R.base_ring().has_coerce_map_from(C.codomain()) :
+                pass
+            else :
+                raise ValueError( "character codomain and representation base ring must be coercible" )
+        if not O.is_monoid_action() :
+            raise ValueError( "monoid structure must be compatible with group action" )
+        
+        self.__O = O
+        self.__C = C
+        self.__R = R
+        
+        ConstructionFunctor.__init__(self, Rings(), Rings())
+        
+    def __call__(self, P) :
+        r"""
+        Map a monoid power series to a symmetrisation extending the associated representation.
+
+        INPUT:
+            - `P` -- An instance of :class:`~from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient.MonoidPowerSeriesAmbient_abstract`.
+        
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationRingFunctor, MonoidPowerSeriesRingFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
+            sage: mps = MonoidPowerSeriesRingFunctor(NNMonoid(False))(QQ)
+            sage: F = MonoidPowerSeriesSymmetrisationRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: emps = F(mps)
+            sage: emps.representation() == TrivialRepresentation("1", QQ)
+            True
+            sage: mps = MonoidPowerSeriesRingFunctor(NNMonoid(False))(ZZ)
+            sage: F = MonoidPowerSeriesSymmetrisationRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", QQ))
+            sage: emps = F(mps)
+            sage: emps.representation() == TrivialRepresentation("1", QQ)
+            True
+        """
+        if self.__O.monoid() != P.monoid() :
+            raise ValueError( "Action has to be defined on the monoid associated to P." )
+        
+        PR = self.__R.from_module(P.coefficient_domain())
+        
+        if not self.__R.base_ring().has_coerce_map_from(PR.base_ring()) : 
+            R = self.__R.base_extend( pushout(self.__R.base_ring(), PR.base_ring()) )
+        else :
+            R = self.__R
+        
+        from monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing
+
+        return EquivariantMonoidPowerSeriesRing( self.__O, self.__C, R )
+        
+    def __cmp__(self, other) :
+        r"""
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationRingFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
+            sage: F = MonoidPowerSeriesSymmetrisationRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: F == MonoidPowerSeriesSymmetrisationRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            True
+            sage: F == MonoidPowerSeriesSymmetrisationRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", QQ))
+            False
+        """
+        c = cmp(type(self), type(other))
+        if c == 0 :
+            c = cmp(self.__R, other.__R)
+        if c == 0 :
+            c = cmp(self.__O, other.__O)
+        if c == 0 :
+            c = cmp(self.__C, other.__C)
+           
+        return c
+
+    def merge(self, other) :
+        r"""
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationRingFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
+            sage: F = MonoidPowerSeriesSymmetrisationRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: G = MonoidPowerSeriesSymmetrisationRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", QQ))
+            sage: F.merge(G) == G
+            True
+            sage: G = MonoidPowerSeriesSymmetrisationRingFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(QQ, 3)))
+            sage: F.merge(G) is None
+            True
+        """
+        if self == other :
+            return self
+        elif type(self) == type(other) and \
+           self.__O == self.__O :
+            try :
+                if self.__C.extends(other.__C) and self.__R.extends(other.__R) :
+                    return self
+                elif other.__C.extends(self.__C) and other.__R.extends(self.__R) :
+                    return other
+            except AttributeError :
+                return None
+        
+        return None
+
+#===============================================================================
+# MonoidPowerSeriesSymmetrisationModuleFunctor
+#===============================================================================
+
+class MonoidPowerSeriesSymmetrisationModuleFunctor ( ConstructionFunctor) :
+    r"""
+    A functor mapping rings or modules of monoid power series
+    to a the an equivariant power series via symmetrisation.
+    """
+    
+    rank = 9
+    
+    def __init__(self, O, C, R) :
+        r"""
+        INPUT:
+            - `O` -- An action of a group `G` on a monoid as implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.NNMonoid`.
+            - `C` -- A monoid of charcters `G -> K` for a ring `K`. As implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.CharacterMonoid_class`.
+            - `R` -- A representation of `G` on some `K`-algebra or module `A`.
+                     As implemented in :class:`~fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basismonoids.TrivialRepresentation`.
+        
+        TESTS::
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationModuleFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
+            sage: F = MonoidPowerSeriesSymmetrisationModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 1)))
         """
         if O.group() != C.group() :
             raise ValueError, "The action on S and the characters must have the same group"
@@ -307,60 +665,52 @@ class MonoidPowerSeriesSymmetrisationFunctor ( ConstructionFunctor) :
         self.__C = C
         self.__R = R
         
-        ## TODO: replace Rings by an suitable category
-        ConstructionFunctor.__init__(self, Rings(), Rings())
+        ConstructionFunctor.__init__(self, CommutativeAdditiveGroups(), CommutativeAdditiveGroups())
         
     def __call__(self, P) :
-        """
+        r"""
         Map a monoid power series to a symmetrisation extending the associated representation.
 
         INPUT:
             - `P` -- An instance of :class:`~from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient.MonoidPowerSeriesAmbient_abstract`.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationFunctor, MonoidPowerSeriesFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationModuleFunctor, MonoidPowerSeriesModuleFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
-            sage: mps = MonoidPowerSeriesFunctor(NNMonoid(False))(QQ)
-            sage: F = MonoidPowerSeriesSymmetrisationFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: mps = MonoidPowerSeriesModuleFunctor(ZZ, NNMonoid(False))(FreeModule(QQ, 1))
+            sage: F = MonoidPowerSeriesSymmetrisationModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 1)))
             sage: emps = F(mps)
-            sage: emps.representation() == TrivialRepresentation("1", QQ)
+            sage: emps.representation() == TrivialRepresentation("1", FreeModule(QQ, 1))
             True
-            sage: mps = MonoidPowerSeriesFunctor(NNMonoid(False))(ZZ)
-            sage: F = MonoidPowerSeriesSymmetrisationFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", QQ))
+            sage: mps = MonoidPowerSeriesModuleFunctor(ZZ, NNMonoid(False))(FreeModule(ZZ, 1))
+            sage: F = MonoidPowerSeriesSymmetrisationModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(QQ, 1)))
             sage: emps = F(mps)
-            sage: emps.representation() == TrivialRepresentation("1", QQ)
+            sage: emps.representation() == TrivialRepresentation("1", FreeModule(QQ, 1))
             True
-            sage: mps = MonoidPowerSeriesFunctor(NNMonoid(False))(FreeModule(ZZ, 3))
-            sage: F(mps)
-            Traceback (most recent call last):
-            ...
-            TypeError: no base extension defined
         """
         if self.__O.monoid() != P.monoid() :
             raise ValueError( "Action has to be defined on the monoid associated to P." )
-        if not self.__R.base_ring().has_coerce_map_from(P.base_ring()) : 
-            R = self.__R.base_extend(P.base_ring())
+        
+        PR = self.__R.from_module(P.coefficient_domain())
+        
+        if not self.__R.base_ring().has_coerce_map_from(PR.base_ring()) : 
+            R = self.__R.base_extend( pushout(self.__R.base_ring(), PR.base_ring()) )
         else :
             R = self.__R
         
-        if self.__O.is_monoid_action() and isinstance(R.codomain(), Ring) :
-            from monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing
+        from monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
 
-            return EquivariantMonoidPowerSeriesRing( self.__O, self.__C, R )
-        else :
-            from monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
-
-            return EquivariantMonoidPowerSeriesModule( self.__O, self.__C, R )
+        return EquivariantMonoidPowerSeriesModule( self.__O, self.__C, R )
 
     def __cmp__(self, other) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationModuleFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
-            sage: F = MonoidPowerSeriesSymmetrisationFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
-            sage: F == MonoidPowerSeriesSymmetrisationFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
+            sage: F = MonoidPowerSeriesSymmetrisationModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 1)))
+            sage: F == MonoidPowerSeriesSymmetrisationModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 1)))
             True
-            sage: F == MonoidPowerSeriesSymmetrisationFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", QQ))
+            sage: F == MonoidPowerSeriesSymmetrisationModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(QQ, 1)))
             False
         """
         c = cmp(type(self), type(other))
@@ -374,15 +724,15 @@ class MonoidPowerSeriesSymmetrisationFunctor ( ConstructionFunctor) :
         return c
 
     def merge(self, other) :
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationFunctor
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesSymmetrisationModuleFunctor
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid, TrivialRepresentation, TrivialCharacterMonoid
-            sage: F = MonoidPowerSeriesSymmetrisationFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ))
-            sage: G = MonoidPowerSeriesSymmetrisationFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", QQ))
+            sage: F = MonoidPowerSeriesSymmetrisationModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 1)))
+            sage: G = MonoidPowerSeriesSymmetrisationModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(QQ, 1)))
             sage: F.merge(G) == G
             True
-            sage: G = MonoidPowerSeriesSymmetrisationFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(QQ, 3)))
+            sage: G = MonoidPowerSeriesSymmetrisationModuleFunctor(NNMonoid(), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(QQ, 3)))
             sage: F.merge(G) is None
             True
         """
@@ -405,29 +755,32 @@ class MonoidPowerSeriesSymmetrisationFunctor ( ConstructionFunctor) :
 #===============================================================================
 
 class MonoidPowerSeriesBaseRingInjection ( Morphism ) :
-    """
+    r"""
     The injection of the base ring into a (equivariant) monoid power
     series ring.
     """
     
     def __init__(self, domain, codomain) :
-        """
+        r"""
         INPUT:
             - ``domain``   -- A ring; The base ring.
             - ``codomain`` -- A ring; The ring of monoid power series.
         
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesFunctor, MonoidPowerSeriesBaseRingInjection
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesRingFunctor, MonoidPowerSeriesModuleFunctor, MonoidPowerSeriesBaseRingInjection
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
-            sage: mps = MonoidPowerSeriesFunctor(NNMonoid(False))(ZZ)
+            sage: mps = MonoidPowerSeriesRingFunctor(NNMonoid(False))(ZZ)
             sage: binj = MonoidPowerSeriesBaseRingInjection(ZZ, mps)
+            sage: mps = MonoidPowerSeriesModuleFunctor(ZZ,NNMonoid(False))(FreeModule(ZZ, 1))
+            sage: binj = MonoidPowerSeriesBaseRingInjection(ZZ, mps)
+
         """
         Morphism.__init__(self, domain, codomain)
         
         self._repr_type_str = "MonoidPowerSeries base injection"
 
     def _call_(self, x) :
-        """
+        r"""
         Coerce an element into the ring of monoid power series.
         
         INPUT:
@@ -437,9 +790,9 @@ class MonoidPowerSeriesBaseRingInjection ( Morphism ) :
             An element of a ring. 
             
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesFunctor, MonoidPowerSeriesBaseRingInjection
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesRingFunctor, MonoidPowerSeriesBaseRingInjection
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
-            sage: mps = MonoidPowerSeriesFunctor(NNMonoid(False))(ZZ)
+            sage: mps = MonoidPowerSeriesRingFunctor(NNMonoid(False))(ZZ)
             sage: binj = MonoidPowerSeriesBaseRingInjection(ZZ, mps)
             sage: binj(1)
             Monoid power series in Ring of monoid power series over NN
@@ -447,11 +800,11 @@ class MonoidPowerSeriesBaseRingInjection ( Morphism ) :
         return self.codomain()._element_constructor_(x)
             
     def _call_with_args(self, x, *args, **kwds):
-        """
+        r"""
         TESTS::
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesFunctor, MonoidPowerSeriesBaseRingInjection
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesRingFunctor, MonoidPowerSeriesBaseRingInjection
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import NNMonoid
-            sage: mps = MonoidPowerSeriesFunctor(NNMonoid(False))(ZZ)
+            sage: mps = MonoidPowerSeriesRingFunctor(NNMonoid(False))(ZZ)
             sage: binj = MonoidPowerSeriesBaseRingInjection(ZZ, mps)
             sage: binj._call_with_args(1)
             Monoid power series in Ring of monoid power series over NN

--- a/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_lazyelement.py
+++ b/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_lazyelement.py
@@ -37,7 +37,7 @@ from sage.rings.ring import Ring
 #===============================================================================
 
 def EquivariantMonoidPowerSeries_lazy(parent, precision, coefficient_function, components = None, bounding_precision = None) :
-    """
+    r"""
     Construct a equivariant monoid power series, which calculates its coefficients
     on demand.
     
@@ -83,13 +83,13 @@ def EquivariantMonoidPowerSeries_lazy(parent, precision, coefficient_function, c
 #===============================================================================
 
 class EquivariantMonoidPowerSeries_abstract_lazy (EquivariantMonoidPowerSeries_abstract) :
-    """
+    r"""
     This class implements an equivariant monoid power series which calculates the
     coefficients on demand.
     """
 
     def __init__(self, parent, precision, coefficient_function, components, bounding_precision = None ) :
-        """
+        r"""
         INPUT:
             - ``parent``               -- An instance of :class:~`fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient.MonoidPowerSeriesAmbient_abstract`.
             - ``precision``            -- A filter for the parent's action.
@@ -118,7 +118,7 @@ class EquivariantMonoidPowerSeries_abstract_lazy (EquivariantMonoidPowerSeries_a
         self.__components = components
         
     def non_zero_components(self) :
-        """
+        r"""
         Return all those characters which are not guaranteed to have only
         vanishing coefficients associated with.
 
@@ -147,7 +147,7 @@ class EquivariantMonoidPowerSeries_abstract_lazy (EquivariantMonoidPowerSeries_a
         return self.__components
     
     def _bounding_precision(self) :
-        """
+        r"""
         If a filter for the vanishing of coefficients is given return this. Otherwise,
         return the precision, which is then guaranteed to be finite.
 
@@ -190,7 +190,7 @@ class EquivariantMonoidPowerSeries_abstract_lazy (EquivariantMonoidPowerSeries_a
         return self.precision()
     
     def coefficients(self, force_characters = False) :
-        """
+        r"""
         Evaluate all coefficients within the precision bounds and return a
         dictionary which saves all coefficients of this element.
     
@@ -243,7 +243,7 @@ class EquivariantMonoidPowerSeries_abstract_lazy (EquivariantMonoidPowerSeries_a
             return self.__coefficients
 
     def _truncate_in_place(self, precision) :
-        """
+        r"""
         Truncate ``self`` modifying also the coefficient cache.
         
         INPUT:
@@ -279,7 +279,7 @@ class EquivariantMonoidPowerSeries_abstract_lazy (EquivariantMonoidPowerSeries_a
             self._set_precision(nprec)
 
     def __getitem__(self, k) :
-        """
+        r"""
         Evaluate and return the `k`-th coefficient if it below the series' precision. If no character is contained
         in the key ``self`` must have only one nonvanishing component.
         
@@ -351,12 +351,12 @@ class EquivariantMonoidPowerSeries_abstract_lazy (EquivariantMonoidPowerSeries_a
 #===============================================================================
 
 class EquivariantMonoidPowerSeries_moduleelement_lazy (EquivariantMonoidPowerSeries_abstract_lazy, ModuleElement) :
-    """
+    r"""
     A lazy element of a module of equivariant monoid power series.
     """
 
     def __init__(self, parent, precision, coefficient_function, components, bounding_precision ) :
-        """
+        r"""
         INPUT:
             - ``parent``       -- An instance of :class:~`fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient.MonoidPowerSeriesAmbient_abstract`.
             - ``precision``    -- A filter for the parent's action.
@@ -382,12 +382,12 @@ class EquivariantMonoidPowerSeries_moduleelement_lazy (EquivariantMonoidPowerSer
 #===============================================================================
 
 class EquivariantMonoidPowerSeries_algebraelement_lazy (EquivariantMonoidPowerSeries_abstract_lazy, AlgebraElement) :
-    """
+    r"""
     A lazy element of an algebra of equivariant monoid power series.
     """
 
     def __init__(self, parent, precision, coefficient_function, components, bounding_precision ) :
-        """
+        r"""
         INPUT:
             - ``parent``       -- An instance of :class:~`fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient.MonoidPowerSeriesAmbient_abstract`.
             - ``precision``    -- A filter for the parent's action.
@@ -412,12 +412,12 @@ class EquivariantMonoidPowerSeries_algebraelement_lazy (EquivariantMonoidPowerSe
 #===============================================================================
 
 class EquivariantMonoidPowerseries_MultiplicationDelayedFactory :
-    """
+    r"""
     A helper class for lazy multplication of equivariant monoid power series.
     """
     
     def __init__( self, left, right ) :
-        """
+        r"""
         INPUT:
             - ``left``  -- An instance of :class:~`fourier_expansion_framework.monoidpowerseries.EquivariantMonoidPowerSeries_abstract`.
             - ``right`` -- An instance of :class:~`fourier_expansion_framework.monoidpowerseries.EquivariantMonoidPowerSeries_abstract`.
@@ -447,7 +447,7 @@ class EquivariantMonoidPowerseries_MultiplicationDelayedFactory :
         self.__right_coefficients = None
 
     def getcoeff(self, (ch, k)) :
-        """
+        r"""
         Return the `k`-th coefficient of the component ``ch`` of the product.
         
         INPUT:
@@ -490,7 +490,7 @@ class EquivariantMonoidPowerseries_MultiplicationDelayedFactory :
 #===============================================================================
 
 def EquivariantMonoidPowerSeries_LazyMultiplication(left, right) :
-    """
+    r"""
     The product of two equivariant monoid power series which is only evaluated
     if a coefficient is demanded.
     

--- a/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_module.py
+++ b/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_module.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Modules of monoid power series and modules of equivariant monoid power series.
 
 AUTHOR :
@@ -27,8 +27,6 @@ AUTHOR :
 from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient import MonoidPowerSeriesAmbient_abstract,\
                                       EquivariantMonoidPowerSeriesAmbient_abstract
 from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialRepresentation
-from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesFunctor,\
-    MonoidPowerSeriesFunctor
 from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing, \
                                    EquivariantMonoidPowerSeriesRing
 from sage.modules.module import Module
@@ -43,7 +41,7 @@ _equivariantmonoidpowerseries_module_cache = dict()
 #===============================================================================
 
 def MonoidPowerSeriesModule(A, S) :
-    """
+    r"""
     Return the globally unique monoid power series ring with indices
     in the filtered monoid `S` and coefficients in `A`.
     
@@ -74,7 +72,7 @@ def MonoidPowerSeriesModule(A, S) :
 #===============================================================================
 
 class MonoidPowerSeriesModule_generic ( MonoidPowerSeriesAmbient_abstract, Module ) :
-    """
+    r"""
     Given some `K` module `A` and a monoid `S` filtered over
     a net `\Lambda` construct a module of monoid power series.
     
@@ -87,7 +85,7 @@ class MonoidPowerSeriesModule_generic ( MonoidPowerSeriesAmbient_abstract, Modul
     """
 
     def __init__(self, A, S) :
-        """
+        r"""
         INPUT:
             - `A` -- A module.
             - `S` -- A monoid as implemented in :class:~`fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids.NNMonoid`.
@@ -96,7 +94,12 @@ class MonoidPowerSeriesModule_generic ( MonoidPowerSeriesAmbient_abstract, Modul
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import MonoidPowerSeriesModule_generic
             sage: mps = MonoidPowerSeriesModule_generic(FreeModule(QQ,2), NNMonoid(False))
-        """       
+            sage: mps = MonoidPowerSeriesModule_generic(FreeModule(ZZ,2), NNMonoid(False))
+            sage: mps.base_ring()
+            Ring of monoid power series over NN
+            sage: (1 / 2) * mps.0
+            Monoid power series in Module of monoid power series over NN
+        """
         Module.__init__(self, MonoidPowerSeriesRing(A.base_ring(), S))
         MonoidPowerSeriesAmbient_abstract.__init__(self, A, S)
         
@@ -106,7 +109,7 @@ class MonoidPowerSeriesModule_generic ( MonoidPowerSeriesAmbient_abstract, Modul
             for a in A.gens() ]
 
     def ngens(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import MonoidPowerSeriesModule_generic
@@ -117,7 +120,7 @@ class MonoidPowerSeriesModule_generic ( MonoidPowerSeriesAmbient_abstract, Modul
         return len(self.__coeff_gens)
     
     def gen(self, i = 0) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import MonoidPowerSeriesModule_generic
@@ -128,7 +131,7 @@ class MonoidPowerSeriesModule_generic ( MonoidPowerSeriesAmbient_abstract, Modul
         return self.gens()[i]
         
     def gens(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import MonoidPowerSeriesModule_generic
@@ -139,21 +142,22 @@ class MonoidPowerSeriesModule_generic ( MonoidPowerSeriesAmbient_abstract, Modul
         return self.__coeff_gens
     
     def construction(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import MonoidPowerSeriesModule_generic
             sage: mps = MonoidPowerSeriesModule_generic(FreeModule(QQ,2), NNMonoid(False))
             sage: (f, a) = mps.construction()
             sage: (f, a)
-            (MonoidPowerSeriesFunctor, Vector space of dimension 2 over Rational Field)
+            (MonoidPowerSeriesModuleFunctor, Vector space of dimension 2 over Rational Field)
             sage: f(a) == mps
             True
         """
-        return MonoidPowerSeriesFunctor(self.monoid()), self.coefficient_domain()
+        from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesModuleFunctor
+        return MonoidPowerSeriesModuleFunctor(self.base_ring().coefficient_domain(), self.monoid()), self.coefficient_domain()
 
     def zero_element(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import MonoidPowerSeriesModule_generic
@@ -163,7 +167,7 @@ class MonoidPowerSeriesModule_generic ( MonoidPowerSeriesAmbient_abstract, Modul
         return self(0)
     
     def _element_constructor_(self, x) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import MonoidPowerSeriesModule_generic
@@ -184,7 +188,7 @@ class MonoidPowerSeriesModule_generic ( MonoidPowerSeriesAmbient_abstract, Modul
         return MonoidPowerSeriesAmbient_abstract._element_constructor_(self, x)
  
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import MonoidPowerSeriesModule_generic
@@ -194,14 +198,14 @@ class MonoidPowerSeriesModule_generic ( MonoidPowerSeriesAmbient_abstract, Modul
         return "Module of monoid power series over " + self.monoid()._repr_()
 
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import MonoidPowerSeriesModule_generic
             sage: latex(MonoidPowerSeriesModule_generic(FreeModule(QQ,2), NNMonoid(False)))
-            Module of monoid power series over $\NN$
+            \text{Module of monoid power series over }\Bold{N}
         """
-        return "Module of monoid power series over " + self.monoid()._latex_()
+        return r"\text{Module of monoid power series over }" + self.monoid()._latex_()
     
 ###############################################################################
 ###############################################################################
@@ -212,7 +216,7 @@ class MonoidPowerSeriesModule_generic ( MonoidPowerSeriesAmbient_abstract, Modul
 #===============================================================================
 
 def EquivariantMonoidPowerSeriesModule(O, C, R) :
-    """
+    r"""
     Return the globally unique module of equivariant monoid power
     over the monoid with action `O` with coefficients in the codomain `R`
     with a representation and a set of virtual characters `C`.
@@ -266,7 +270,7 @@ def EquivariantMonoidPowerSeriesModule(O, C, R) :
 #===============================================================================
 
 class EquivariantMonoidPowerSeriesModule_generic ( EquivariantMonoidPowerSeriesAmbient_abstract, Module ) :
-    """
+    r"""
     Given some module `A`, a monoid `S` filtered over some originated
     net `\Lambda` such that all induced submonoids are finite, a group `G`, a
     semigroup `C` with a map `c \rightarrow \mathrm{Hom}(G, Aut_K(A))`, a
@@ -285,7 +289,7 @@ class EquivariantMonoidPowerSeriesModule_generic ( EquivariantMonoidPowerSeriesA
     """
         
     def __init__(self, O, C, R) :
-        """
+        r"""
         INPUT:
             - `O` -- A monoid with an action of a group; As implemented in
                      :class:~`fourier_expansion_framework.monoidpowerseries.NNMonoid`.
@@ -295,8 +299,13 @@ class EquivariantMonoidPowerSeriesModule_generic ( EquivariantMonoidPowerSeriesA
 
         EXAMPLES::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule_generic
             sage: emps = EquivariantMonoidPowerSeriesModule_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", FreeModule(QQ, 2))) # indirect doctest
+            sage: emps = EquivariantMonoidPowerSeriesModule_generic(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", FreeModule(ZZ, 2))) # indirect doctest
+            sage: emps.base_ring()
+            Ring of equivariant monoid power series over NN
+            sage: (1 / 2) * emps.0
+            Equivariant monoid power series in Module of equivariant monoid power series over NN
         """
         
         # If the representation O respects the monoid structure of S
@@ -314,10 +323,10 @@ class EquivariantMonoidPowerSeriesModule_generic ( EquivariantMonoidPowerSeriesA
            for a in self.coefficient_domain().gens()]
           
     def ngens(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule_generic
             sage: emps = EquivariantMonoidPowerSeriesModule_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", FreeModule(QQ, 2)))
             sage: emps.ngens()
             2
@@ -325,10 +334,10 @@ class EquivariantMonoidPowerSeriesModule_generic ( EquivariantMonoidPowerSeriesA
         return len(self.__coeff_gens)
     
     def gen(self, i = 0) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule_generic
             sage: emps = EquivariantMonoidPowerSeriesModule_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", FreeModule(QQ, 2)))
             sage: emps.gen()
             Equivariant monoid power series in Module of equivariant monoid power series over NN
@@ -336,10 +345,10 @@ class EquivariantMonoidPowerSeriesModule_generic ( EquivariantMonoidPowerSeriesA
         return self.gens()[i]
     
     def gens(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule_generic
             sage: emps = EquivariantMonoidPowerSeriesModule_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", FreeModule(QQ, 2)))
             sage: emps.gens()
             [Equivariant monoid power series in Module of equivariant monoid power series over NN, Equivariant monoid power series in Module of equivariant monoid power series over NN]
@@ -347,35 +356,37 @@ class EquivariantMonoidPowerSeriesModule_generic ( EquivariantMonoidPowerSeriesA
         return self.__coeff_gens
     
     def construction(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule_generic
             sage: emps = EquivariantMonoidPowerSeriesModule_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", FreeModule(QQ, 2)))
             sage: (f, a) = emps.construction()
             sage: (f, a)
-            (EquivariantMonoidPowerSeriesFunctor, Rational Field)
+            (EquivariantMonoidPowerSeriesModuleFunctor, Rational Field)
             sage: f(a) == emps
             True
         """
-        return EquivariantMonoidPowerSeriesFunctor(self.action(), self.characters(), self.representation()), \
+        from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesModuleFunctor
+
+        return EquivariantMonoidPowerSeriesModuleFunctor(self.action(), self.characters(), self.representation()), \
                self.coefficient_domain().base_ring()
     
     def zero_element(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule_generic
             sage: emps = EquivariantMonoidPowerSeriesModule_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", FreeModule(QQ, 2)))
             sage: h = emps.zero_element()
         """
         return self(0)
     
     def _element_constructor_(self, x) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule_generic
             sage: emps = EquivariantMonoidPowerSeriesModule_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", FreeModule(QQ, 2)))
             sage: h = emps(0) # indirect doctest
             sage: h = emps(int(0)) # indirect doctest
@@ -398,21 +409,21 @@ class EquivariantMonoidPowerSeriesModule_generic ( EquivariantMonoidPowerSeriesA
         return EquivariantMonoidPowerSeriesAmbient_abstract._element_constructor_(self, x)
 
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule_generic
             sage: EquivariantMonoidPowerSeriesModule_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", FreeModule(QQ, 2)))
             Module of equivariant monoid power series over NN
         """
         return "Module of equivariant monoid power series over " + self.monoid()._repr_()
 
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
-            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule
+            sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_module import EquivariantMonoidPowerSeriesModule_generic
             sage: latex( EquivariantMonoidPowerSeriesModule_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", FreeModule(QQ, 2))) )
-            Module of equivariant monoid power series over $\NN$
+            \text{Module of equivariant monoid power series over }\Bold{N}
         """
-        return "Module of equivariant monoid power series over " + self.monoid()._latex_()
+        return r"\text{Module of equivariant monoid power series over }" + self.monoid()._latex_()

--- a/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_ring.py
+++ b/psage/modform/fourier_expansion_framework/monoidpowerseries/monoidpowerseries_ring.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Rings of monoid power series and rings of equivariant monoid power series.
 
 AUTHOR :
@@ -26,8 +26,6 @@ AUTHOR :
 
 from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient import MonoidPowerSeriesAmbient_abstract, \
                                       EquivariantMonoidPowerSeriesAmbient_abstract
-from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesBaseRingInjection,\
-    EquivariantMonoidPowerSeriesFunctor, MonoidPowerSeriesFunctor
 from sage.algebras.algebra import Algebra
 from sage.rings.all import Integer
 from sage.structure.element import Element
@@ -40,7 +38,7 @@ from sage.structure.parent import Parent
 _monoidpowerseries_ring_cache = dict()
 
 def MonoidPowerSeriesRing(A, S) :
-    """
+    r"""
     Return the globally unique monoid power series ring with indices
     over the filtered monoid `S` and coefficients in `A`.
     
@@ -74,7 +72,7 @@ def MonoidPowerSeriesRing(A, S) :
 #===============================================================================
 
 class MonoidPowerSeriesRing_generic ( MonoidPowerSeriesAmbient_abstract, Algebra ) :
-    """
+    r"""
     Given some `K` algebra `A` and a monoid `S` filtered over
     a net `\Lambda` construct a ring of monoid power series.
     
@@ -84,7 +82,7 @@ class MonoidPowerSeriesRing_generic ( MonoidPowerSeriesAmbient_abstract, Algebra
     """
     
     def __init__(self, A, S) :
-        """
+        r"""
         INPUT:
             - `A` -- A ring.
             - `S` -- A monoid as implemented in :class:~`fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids.NNMonoid`.
@@ -93,6 +91,11 @@ class MonoidPowerSeriesRing_generic ( MonoidPowerSeriesAmbient_abstract, Algebra
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing_generic
             sage: mps = MonoidPowerSeriesRing_generic(QQ, NNMonoid(False))
+            sage: mps = MonoidPowerSeriesRing_generic(ZZ, NNMonoid(False))
+            sage: mps.base_ring()
+            Integer Ring
+            sage: (1 / 2) * mps.0
+            Monoid power series in Ring of monoid power series over NN
         """
         Algebra.__init__(self, A)        
         MonoidPowerSeriesAmbient_abstract.__init__(self, A, S)
@@ -102,12 +105,14 @@ class MonoidPowerSeriesRing_generic ( MonoidPowerSeriesAmbient_abstract, Algebra
                                     self.monoid().filter_all() )
             for s in S.gens() ]
     
+        from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesBaseRingInjection
+
         self._populate_coercion_lists_(
           coerce_list = [MonoidPowerSeriesBaseRingInjection(self.base_ring(), self)] + \
                         ([S] if isinstance(S, Parent) else []) )
     
     def ngens(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing_generic
@@ -118,7 +123,7 @@ class MonoidPowerSeriesRing_generic ( MonoidPowerSeriesAmbient_abstract, Algebra
         return len(self.__monoid_gens)
 
     def gen(self, i = 0) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing_generic
@@ -129,7 +134,7 @@ class MonoidPowerSeriesRing_generic ( MonoidPowerSeriesAmbient_abstract, Algebra
         return self.gens()[i]
     
     def gens(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing_generic
@@ -140,21 +145,23 @@ class MonoidPowerSeriesRing_generic ( MonoidPowerSeriesAmbient_abstract, Algebra
         return self.__monoid_gens
     
     def construction(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing_generic
             sage: mps = MonoidPowerSeriesRing_generic(QQ, NNMonoid(False))
             sage: (f, a) = mps.construction()
             sage: (f, a)
-            (MonoidPowerSeriesFunctor, Rational Field)
+            (MonoidPowerSeriesRingFunctor, Rational Field)
             sage: f(a) == mps
             True
         """
-        return MonoidPowerSeriesFunctor(self.monoid()), self.coefficient_domain()
+        from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesRingFunctor
+
+        return MonoidPowerSeriesRingFunctor(self.monoid()), self.coefficient_domain()
     
     def _element_constructor_(self, x) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing_generic
@@ -186,7 +193,7 @@ class MonoidPowerSeriesRing_generic ( MonoidPowerSeriesAmbient_abstract, Algebra
         return MonoidPowerSeriesAmbient_abstract._element_constructor_(self, x)
     
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing_generic
@@ -196,14 +203,14 @@ class MonoidPowerSeriesRing_generic ( MonoidPowerSeriesAmbient_abstract, Algebra
         return "Ring of monoid power series over " + self.monoid()._repr_()
 
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing_generic
             sage: latex(MonoidPowerSeriesRing_generic(QQ, NNMonoid(False)))
-            Ring of monoid power series over $\NN$
+            \text{Ring of monoid power series over }\Bold{N}
         """
-        return "Ring of monoid power series over " + self.monoid()._latex_()
+        return r"\text{Ring of monoid power series over }" + self.monoid()._latex_()
     
 ###############################################################################
 ###############################################################################
@@ -216,7 +223,7 @@ class MonoidPowerSeriesRing_generic ( MonoidPowerSeriesAmbient_abstract, Algebra
 _equivariantmonoidpowerseries_ring_cache = dict()
 
 def EquivariantMonoidPowerSeriesRing(O, C, R) :
-    """
+    r"""
     Return the globally unique ring of equivariant monoid power
     over the monoid with action `O` with coefficients in the codomain `R`
     with a representation and a set of virtual characters `C`.
@@ -270,7 +277,7 @@ def EquivariantMonoidPowerSeriesRing(O, C, R) :
 #===============================================================================
 
 class EquivariantMonoidPowerSeriesRing_generic ( EquivariantMonoidPowerSeriesAmbient_abstract, Algebra ) :
-    """
+    r"""
     Given some ring `A`, a monoid `S` filtered over some originated
     net `\Lambda` such that all induced submonoids are finite, a group `G`, a
     semigroup `C` with a map `c \rightarrow \mathrm{Hom}(G, Aut_K(A))`, a
@@ -289,7 +296,7 @@ class EquivariantMonoidPowerSeriesRing_generic ( EquivariantMonoidPowerSeriesAmb
     """
         
     def __init__(self, O, C, R) :
-        """
+        r"""
         INPUT:
             - `O` -- A monoid with an action of a group; As implemented in
                      :class:~`fourier_expansion_framework.monoidpowerseries.NNMonoid`.
@@ -301,6 +308,11 @@ class EquivariantMonoidPowerSeriesRing_generic ( EquivariantMonoidPowerSeriesAmb
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing_generic
             sage: emps = EquivariantMonoidPowerSeriesRing_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", QQ)) # indirect doctest
+            sage: emps = EquivariantMonoidPowerSeriesRing_generic(NNMonoid(True), TrivialCharacterMonoid("1", ZZ), TrivialRepresentation("1", ZZ)) # indirect doctest
+            sage: emps.base_ring()
+            Integer Ring
+            sage: (1 / 2) * emps.0
+            Equivariant monoid power series in Ring of equivariant monoid power series over NN
         """
         
         Algebra.__init__(self, R.base_ring())
@@ -322,12 +334,14 @@ class EquivariantMonoidPowerSeriesRing_generic ( EquivariantMonoidPowerSeriesAmb
             self.monoid().filter_all() )
            for g in self.coefficient_domain().gens()]
         
+        from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import MonoidPowerSeriesBaseRingInjection
+
         self._populate_coercion_lists_(
           coerce_list = [MonoidPowerSeriesBaseRingInjection(R.codomain(), self)] ,
           convert_list = ([O.monoid()] if isinstance(O.monoid(), Parent) else []) )
 
     def ngens(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing_generic
@@ -338,7 +352,7 @@ class EquivariantMonoidPowerSeriesRing_generic ( EquivariantMonoidPowerSeriesAmb
         return len(self.__monoid_gens) + len(self.__character_gens) + len(self.__coefficient_gens)
     
     def gen(self, i = 0) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing_generic
@@ -349,7 +363,7 @@ class EquivariantMonoidPowerSeriesRing_generic ( EquivariantMonoidPowerSeriesAmb
         return self.gens()[i]
   
     def gens(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing_generic
@@ -360,22 +374,24 @@ class EquivariantMonoidPowerSeriesRing_generic ( EquivariantMonoidPowerSeriesAmb
         return self.__monoid_gens + self.__character_gens + self.__coefficient_gens
 
     def construction(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing_generic
             sage: emps = EquivariantMonoidPowerSeriesRing_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", QQ))
             sage: (f, a) = emps.construction()
             sage: (f, a)
-            (EquivariantMonoidPowerSeriesFunctor, Rational Field)
+            (EquivariantMonoidPowerSeriesRingFunctor, Rational Field)
             sage: f(a) == emps
             True
         """
-        return EquivariantMonoidPowerSeriesFunctor(self.action(), self.characters(), self.representation()), \
+        from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_functor import EquivariantMonoidPowerSeriesRingFunctor
+
+        return EquivariantMonoidPowerSeriesRingFunctor(self.action(), self.characters(), self.representation()), \
                self.coefficient_domain()
 
     def _element_constructor_(self, x) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing_generic
@@ -414,7 +430,7 @@ class EquivariantMonoidPowerSeriesRing_generic ( EquivariantMonoidPowerSeriesAmb
         return EquivariantMonoidPowerSeriesAmbient_abstract._element_constructor_(self, x)
 
     def _cmp_(self, other) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import MonoidPowerSeriesRing
@@ -435,7 +451,7 @@ class EquivariantMonoidPowerSeriesRing_generic ( EquivariantMonoidPowerSeriesAmb
         return c
 
     def _repr_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing_generic
@@ -445,11 +461,11 @@ class EquivariantMonoidPowerSeriesRing_generic ( EquivariantMonoidPowerSeriesAmb
         return "Ring of equivariant monoid power series over " + self.monoid()._repr_()
 
     def _latex_(self) :
-        """
+        r"""
         TESTS::
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import *
             sage: from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing_generic
             sage: latex(EquivariantMonoidPowerSeriesRing_generic(NNMonoid(True), TrivialCharacterMonoid("1", QQ), TrivialRepresentation("1", QQ)))
-            Ring of equivariant monoid power series over $\NN$
+            \text{Ring of equivariant monoid power series over }\Bold{N}
         """
-        return "Ring of equivariant monoid power series over " + self.monoid()._latex_()
+        return r"\text{Ring of equivariant monoid power series over }" + self.monoid()._latex_()

--- a/psage/modform/paramodularforms/__init__.py
+++ b/psage/modform/paramodularforms/__init__.py
@@ -1,0 +1,9 @@
+from paramodularformd2_types import ParamodularFormsD2, \
+        ParamodularFormD2_Gamma 
+
+from siegelmodularformg2_types import SiegelModularFormsG2, \
+        SiegelModularFormG2_Classical_Gamma, SiegelModularFormG2_VectorValuedW2_Gamma
+                                    
+from siegelmodularformg2_maassproducts import \
+                       spanning_maass_products, \
+                       construct_from_maass_products

--- a/psage/modform/paramodularforms/paramodularformd2_element.py
+++ b/psage/modform/paramodularforms/paramodularformd2_element.py
@@ -1,0 +1,132 @@
+r"""
+Elements of rings of paramodular forms of degree 2.
+
+AUTHORS:
+
+- Martin Raum (2010 - 05 - 06) Initial version.
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.fourier_expansion_framework.modularforms.modularform_element import ModularForm_generic
+from psage.modform.paramodularforms.paramodularformd2_fourierexpansion import ParamodularFormD2Filter_trace
+from psage.modform.paramodularforms.paramodularformd2_fourierexpansion_cython import apply_GL_to_form
+from sage.functions.other import ceil
+from sage.modular.modsym.p1list import P1List
+from sage.rings.all import Integer
+from sage.rings.complex_field import is_ComplexField
+from sage.structure.sequence import Sequence
+
+class ParamodularFormD2_generic :
+
+    def is_cusp_form(self) :
+        raise NotImplementedError
+        
+class ParamodularFormD2_classical ( ParamodularFormD2_generic, ModularForm_generic ) :
+
+    def is_gritsenko_form(self) :
+        raise NotImplementedError    
+
+    def atkin_lehner_eigenvalue_numerical(self, (tau1, z, tau2)) :
+        from sage.libs.mpmath import mp
+        from sage.libs.mpmath.mp import exp, pi
+        from sage.libs.mpmath.mp import j as i
+        
+        if not Integer(self.__level()).is_prime() :
+            raise ValueError, "The Atkin Lehner involution is only unique if the level is a prime"
+        
+        precision = ParamodularFormD2Filter_trace(self.precision())
+        
+        s = Sequence([tau1, z, tau2])
+        if not is_ComplexField(s) :
+            mp_precision = 30
+        else :
+            mp_precision = ceil(3.33 * s.universe().precision() ) 
+        mp.dps = mp_precision
+                
+        (tau1, z, tau2) = tuple(s)
+        (tau1p, zp, tau2p) = (self.level()*tau1, self.level()*z, self.level()*tau2)
+        
+        (e_tau1, e_z, e_tau2) = (exp(2 * pi * i * tau1), exp(2 * pi * i * z), exp(2 * pi * i * tau2))
+        (e_tau1p, e_zp, e_tau2p) = (exp(2 * pi * i * tau1p), exp(2 * pi * i * zp), exp(2 * pi * i * tau2p))
+        
+        self_value = s.universe().zero()
+        trans_value = s.universe().zero()
+        
+        for k in precision :
+            (a,b,c) = apply_GL_to_form(self._P1List()(k[1]), k[0])
+            
+            self_value = self_value + self[k] * (e_tau1**a * e_z**b * e_tau2**c)
+            trans_value = trans_value + self[k] * (e_tau1p**a * e_zp**b * e_tau2p**c)
+        
+        return trans_value / self_value
+    
+    def schmidt_t5_eigenvalue_numerical(self, (tau1, z, tau2)) :
+        from sage.libs.mpmath import mp
+        from sage.libs.mpmath.mp import exp, pi
+        from sage.libs.mpmath.mp import j as i
+        
+        if not Integer(self.__level()).is_prime() :
+            raise ValueError, "T_5 is only unique if the level is a prime"
+        
+        precision = ParamodularFormD2Filter_trace(self.precision())
+        
+        s = Sequence([tau1, z, tau2])
+        if not is_ComplexField(s) :
+            mp_precision = 30
+        else :
+            mp_precision = ceil(3.33 * s.universe().precision())
+        mp.dps = mp_precision
+        
+        p1list = P1List(self.level())
+        
+        ## Prepare the operation for d_1(N)
+        ## We have to invert the lifts since we will later use apply_GL_to_form
+        d1_matrices = [p1list.lift_to_sl2z(i) for i in xrange(len(p1list))]
+        d1_matrices = map(lambda (a,b,c,d): (d,-b,-c,a), d1_matrices)
+        
+        ## Prepare the evaluation points corresponding to d_02(N)
+        d2_points = list()
+        for i in xrange(len(p1list())) :
+            (a, b, c, d) = p1list.lift_to_sl2z(i)
+            tau1p = (a * tau1 + b) / (c * tau1 + d)
+            zp = z / (c * tau1 + d)
+            tau2p = tau2 - c * z**2 / (c * tau1 + d)
+            
+            (e_tau1p, e_zp, e_tau2p) = (exp(2 * pi * i * tau1p), exp(2 * pi * i * zp), exp(2 * pi * i * tau2p))
+            d2_points.append((e_tau1p, e_zp, e_tau2p))
+            
+        (e_tau1, e_z, e_tau2) = (exp(2 * pi * i * tau1), exp(2 * pi * i * z), exp(2 * pi * i * tau2))
+            
+        self_value = s.universe().zero()
+        trans_value = s.universe().zero()
+        
+        for k in precision :
+            (a,b,c) = apply_GL_to_form(self._P1List()(k[1]), k[0])
+            
+            self_value = self_value + self[k] * e_tau1**a * e_z**b * e_tau2**c
+            for m in d1_matrices :
+                (ap, bp, cp) = apply_GL_to_form(m, (a,b,c))
+                
+                for (e_tau1p, e_zp, e_tau2p) in d2_points :
+                    trans_value = trans_value + self[((ap,bp,cp),0)] * e_tau1p**ap * e_zp**bp * e_tau2p**cp
+        
+        return trans_value / self_value
+        

--- a/psage/modform/paramodularforms/paramodularformd2_fegenerators.py
+++ b/psage/modform/paramodularforms/paramodularformd2_fegenerators.py
@@ -1,0 +1,330 @@
+r"""
+Generator functions for the fourier expansion of paramodular modular forms.
+Therefore apply Gritsenko's lift to a Jacobi form of index N. 
+
+AUTHORS:
+
+- Martin Raum (2010 - 04 - 09) Initial version.
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.jacobiforms.jacobiformd1nn_fegenerators import JacobiFormD1NNFactory
+from psage.modform.jacobiforms.jacobiformd1nn_types import JacobiFormsD1NN,\
+    JacobiFormD1NN_Gamma
+from psage.modform.paramodularforms.paramodularformd2_fourierexpansion import ParamodularFormD2Filter_discriminant
+from psage.modform.paramodularforms.paramodularformd2_fourierexpansion import ParamodularFormD2FourierExpansionRing
+from psage.modform.paramodularforms.paramodularformd2_fourierexpansion_cython import apply_GL_to_form
+from psage.modform.paramodularforms.siegelmodularformg2_types import SiegelModularFormsG2,\
+    SiegelModularFormG2_Classical_Gamma
+from sage.matrix.constructor import matrix
+from sage.misc.cachefunc import cached_function
+from sage.misc.cachefunc import cached_method
+from sage.rings.arith import bernoulli, sigma
+from sage.rings.arith import random_prime
+from sage.rings.all import GF
+from sage.rings.integer import Integer
+from sage.rings.integer_ring import ZZ
+from sage.rings.rational_field import QQ
+from sage.structure.all import Sequence
+from sage.structure.sage_object import SageObject
+from psage.modform.paramodularforms.siegelmodularformg2_misc_cython import divisor_dict
+
+#===============================================================================
+# _minimal_paramodular_precision
+#===============================================================================
+
+def _minimal_paramodular_precision(level, weight) :
+    ## This is the bound, that Poor and Yuen provide in Paramodular
+    ## cusp forms, Corollary 5.7
+
+    if Integer(level).is_prime() :
+        return ParamodularFormD2Filter_discriminant( 2 * weight**2 / Integer(225)
+                                                     * (1 + level**2)**2 / Integer(1 + level)**2,
+                                                     2 )
+    else :
+        raise NotImplementedError( "Minimal bound can only be provided for prime level" )
+
+def symmetrise_siegel_modular_form(f, level, weight) :
+    """
+    ALGORITHM:
+        We use the Hecke operators \delta_p and [1,level,1,1/level], where the last one
+        can be chosen, since we assume that f is invariant with respect to the full
+        Siegel modular group. 
+    """
+    if not Integer(level).is_prime() :
+        raise NotImplementedError( "Symmetrisation is only implemented for prime levels" )
+    fr = ParamodularFormD2FourierExpansionRing(f.parent().coefficient_domain(), level)
+    
+    precision = ParamodularFormD2Filter_discriminant(f.precision().discriminant() // level**2, level)
+
+    coeffs = dict()
+    for (k,l) in precision :
+        kp = apply_GL_to_form(precision._p1list()[l], k)
+        coeffs[(k,l)] = f[kp]
+
+    g1 = fr( {fr.characters().one_element() : coeffs} )
+    g1._set_precision(precision)
+    g1._cleanup_coefficients()
+
+    coeffs = dict()
+    for (k,l) in precision :
+        kp = apply_GL_to_form(precision._p1list()[l], k)
+        if kp[1] % level == 0 and kp[2] % level**2 == 0 :
+            coeffs[(k,l)] = f[(kp[0], kp[1] // level, kp[2] // level**2)]
+
+    g2 = fr( {fr.characters().one_element() : coeffs} )
+    g2._set_precision(precision)
+    g2._cleanup_coefficients()
+
+    return g1 + level**(weight-1) * g2
+
+#===============================================================================
+# symmetrised_siegel_modular_forms
+#===============================================================================
+
+def symmetrised_siegel_modular_forms(level, weight, precision) :
+    min_precision = _minimal_paramodular_precision(level, weight)
+    if precision is None :
+        precision = min_precision
+    else :
+        precision = max(precision, min_precision)
+
+    sr = SiegelModularFormsG2( QQ, SiegelModularFormG2_Classical_Gamma(),
+                               precision._enveloping_discriminant_bound() * level**2 )
+    return map( lambda b: symmetrise_siegel_modular_form(b.fourier_expansion(), level, weight),
+                sr.graded_submodule(weight).basis() )
+    
+#===============================================================================
+# gritsenko_lift_fourier_expansion
+#===============================================================================
+
+_gritsenko_lift_factory_cache = dict()
+
+def gritsenko_lift_fourier_expansion(f, precision, is_integral = False) :
+    """
+    Given initial data return the Fourier expansion of a Gritsenko lift
+    for given level and weight.
+    
+    INPUT:
+    
+        - `f` -- A Jacobi form.
+        
+    OUTPUT:
+    
+        A dictionary of coefficients.
+        
+    TODO:
+    
+        Make this return lazy power series.
+    """
+    global _gritsenko_lift_factory_cache
+    N = f.parent().type().index()
+    
+    try :
+        fact = _gritsenko_lift_factory_cache[(precision, N)]
+    except KeyError :
+        fact = ParamodularFormD2Factory(precision, N)
+        _gritsenko_lift_factory_cache[(precision, N)] = fact
+    
+    
+    fe = ParamodularFormD2FourierExpansionRing(ZZ, N)(
+           fact.gritsenko_lift(f.fourier_expansion(), f.parent().type().weight(), is_integral) )
+    fe._set_precision(precision)
+    return fe
+
+#===============================================================================
+# gritsenko_lift_subspace
+#===============================================================================
+
+@cached_function
+def gritsenko_lift_subspace(N, weight, precision) :
+    """
+    Return a list of data, which can be used by the Fourier expansion
+    generator, for the space of Gritsenko lifts.
+    
+    INPUT:
+        - `N`           -- the level of the paramodular group 
+        - ``weight``    -- the weight of the space, that we consider
+        - ``precision`` -- A precision class 
+        
+    NOTE:
+        The lifts returned have to have integral Fourier coefficients.
+    """
+    jf = JacobiFormsD1NN( QQ, JacobiFormD1NN_Gamma(N, weight),
+                          (4 * N**2 + precision._enveloping_discriminant_bound() - 1)//(4 * N) + 1)
+
+    return Sequence( [ gritsenko_lift_fourier_expansion( g if i != 0 else (bernoulli(weight) / (2 * weight)).denominator() * g,
+                                                         precision, True )
+                       for (i,g) in enumerate(jf.gens()) ],
+                       universe = ParamodularFormD2FourierExpansionRing(ZZ, N), immutable = True,
+                       check = False )
+    
+#===============================================================================
+# gritsenko_products
+#===============================================================================
+
+def gritsenko_products(N, weight, dimension, precision = None) :
+    """
+    INPUT:
+        - `N`           -- the level of the paramodular group.
+        - ``weight``    -- the weight of the space, that we consider.
+        - ``precision`` -- the precision to be used for the underlying
+                           Fourier expansions.
+    """
+    min_precision = _minimal_paramodular_precision(N, weight)
+    if precision is None :
+        precision = min_precision
+    else :
+        precision = max(precision, min_precision)
+    
+    # - Lifts betrachten
+    # - Zerlegung des Gewichts benutzen, dort Lifts nach und nach
+    #   multiplizieren, um jeweils den Rang der unterliegenden Matrix
+    #   zu bestimmen. Dabei mod p mit zufaelligem p arbeiten
+        
+    fourier_expansions = list(gritsenko_lift_subspace(N, weight, precision))
+    products = [ [(weight, i)] for i in xrange(len(fourier_expansions)) ]
+
+    fourier_indices = list(precision)
+    fourier_matrix = matrix(ZZ, [ [e[k] for k in fourier_indices]
+                                  for e in fourier_expansions] )
+    
+    for k in xrange(min((weight // 2) - ((weight // 2) % 2), weight - 2), 1, -2) :
+        space_k = list(enumerate(gritsenko_lift_subspace(N, k, precision)))
+        space_wk = list(enumerate(gritsenko_lift_subspace(N, weight - k, precision)))
+
+        if len(space_wk) == 0 :
+            continue
+        
+        for (i,f) in space_k :
+            
+            for (j,g) in space_wk :
+                if fourier_matrix.nrows() == dimension :
+                    return products, fourier_expansions
+                
+                cur_fe = f * g
+                # We are using lazy rank checks
+                for p in [random_prime(10**10) for _ in range(2)] :
+                    fourier_matrix_cur = matrix(GF(p), fourier_matrix.nrows() + 1,
+                                                       fourier_matrix.ncols())
+                    fourier_matrix_cur.set_block(0, 0, fourier_matrix)
+                    fourier_matrix_cur.set_block( fourier_matrix.nrows(), 0,
+                                                  matrix(GF(p), 1, [cur_fe[fi] for fi in fourier_indices]) )
+                    
+                    if fourier_matrix_cur.rank() == fourier_matrix_cur.nrows() :
+                        break
+                else :
+                    continue
+                
+                products.append( [(k, i), (weight - k, j)] )
+                fourier_expansions.append(cur_fe)
+                
+                fourier_matrix_cur = matrix( ZZ, fourier_matrix.nrows() + 1,
+                                                 fourier_matrix.ncols() )
+                fourier_matrix_cur.set_block(0, 0, fourier_matrix)
+                fourier_matrix_cur.set_block( fourier_matrix.nrows(), 0,
+                                              matrix(ZZ, 1, [cur_fe[fi] for fi in fourier_indices]) )
+                fourier_matrix = fourier_matrix_cur
+    
+    return products, fourier_expansions
+
+#===============================================================================
+# ParamodularFormD2Factory
+#===============================================================================
+
+_paramodular_form_d2_factory_cache = dict()
+
+def ParamodularFormD2Factory(precision, level) :
+    global _paramodular_form_d2_factory_cache
+
+    if not isinstance(precision, ParamodularFormD2Filter_discriminant) :
+        precision = ParamodularFormD2Filter_discriminant(precision, level)
+        
+    try :
+        return _paramodular_form_d2_factory_cache[precision]
+    except KeyError :
+        tmp = ParamodularFormD2Factory_class(precision)
+        _paramodular_form_d2_factory_cache[precision] = tmp
+        
+        return tmp
+    
+class ParamodularFormD2Factory_class ( SageObject ) :
+    
+    def __init__(self, precision) :
+        self.__precision = precision
+        self.__jacobi_factory = None
+
+    def precision(self) :
+        return self.__precision
+
+    def level(self) :
+        return self.__precision.level()
+
+    def _discriminant_bound(self) :
+        return self.__precision._contained_discriminant_bound()
+    
+    @cached_method
+    def _divisor_dict(self) :
+        return divisor_dict(self._discriminant_bound())
+    
+    def gritsenko_lift(self, f, k, is_integral = False) :
+        """
+        INPUT:
+            - `f` -- the Fourier expansion of a Jacobi form as a dictionary
+        """
+        N = self.level()
+        frN = 4 * N
+        p1list = self.precision()._p1list()
+
+        divisor_dict = self._divisor_dict()
+        
+        ##TODO: Precalculate disc_coeffs or at least use a recursive definition
+        disc_coeffs = dict()
+        coeffs = dict()
+        f_index = lambda d,b : ((d + b**2)//frN, b)
+        
+        for (((a,b,c),l), eps, disc) in self.__precision._iter_positive_forms_with_content_and_discriminant() :
+            (_,bp,_) = apply_GL_to_form(p1list[l], (a,b,c))
+            try :
+                coeffs[((a,b,c),l)] = disc_coeffs[(disc, bp, eps)]
+            except KeyError :
+                disc_coeffs[(disc, bp, eps)] = \
+                    sum(   t**(k-1) * f[ f_index(disc//t**2, (bp // t) % (2 * N)) ]
+                           for t in divisor_dict[eps] )
+ 
+                if disc_coeffs[(disc, bp, eps)]  != 0 :
+                    coeffs[((a,b,c),l)] = disc_coeffs[(disc, bp, eps)]
+
+        for ((a,b,c), l) in self.__precision.iter_indefinite_forms() :
+            if l == 0 :
+                coeffs[((a,b,c),l)] = ( sigma(c, k-1) * f[(0,0)]
+                                        if c != 0 else 
+                                         ( Integer(-bernoulli(k) / Integer(2 * k) * f[(0,0)])
+                                           if is_integral else
+                                           -bernoulli(k) / Integer(2 * k) * f[(0,0)] ) )
+            else :
+                coeffs[((a,b,c),l)] = ( sigma(c//self.level(), k-1) * f[(0,0)]
+                                        if c != 0 else 
+                                         ( Integer(-bernoulli(k) / Integer(2 * k) * f[(0,0)])
+                                           if is_integral else
+                                           -bernoulli(k) / Integer(2 * k) * f[(0,0)] ) )
+        
+        return coeffs

--- a/psage/modform/paramodularforms/paramodularformd2_fourierexpansion.py
+++ b/psage/modform/paramodularforms/paramodularformd2_fourierexpansion.py
@@ -1,0 +1,615 @@
+r"""
+Classes describing the Fourier expansion of Paramodular modular forms.
+
+AUTHORS:
+
+- Martin Raum (2010 - 04 - 09) Initial version
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialCharacterMonoid, \
+                                           TrivialRepresentation
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing
+from psage.modform.jacobiforms.jacobiformd1nn_types import JacobiFormD1NN_Gamma, JacobiFormsD1NN
+from operator import xor
+from psage.modform.paramodularforms.paramodularformd2_fourierexpansion_cython import apply_GL_to_form, reduce_GL#, \
+from sage.functions.other import ceil, floor
+from sage.functions.other import sqrt
+from sage.misc.functional import isqrt
+from sage.misc.latex import latex
+from sage.modular.modsym.p1list import P1List
+from sage.rings.all import Mod
+from sage.rings.arith import gcd, kronecker_symbol
+from sage.rings.arith import legendre_symbol
+from sage.rings.infinity import infinity
+from sage.rings.integer import Integer
+from sage.rings.integer_ring import ZZ
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.structure.sage_object import SageObject
+import itertools
+
+#===============================================================================
+# ParamodularFormD2Indices_discriminant
+#===============================================================================
+
+class ParamodularFormD2Indices_discriminant( SageObject ) :
+    """
+    Associated with a form of level `N`.
+    Indices are pairs of positive binary quadratic forms `(a, b, Nc)` and an
+    element of the projective line over `\ZZ/ N \ZZ` . The last is modeled by an
+    index of the element with in ``P1List(N)``.
+    
+    A pair `(t, v)` of a quadratic form and a left coset representative represents
+    the equivalence class `v^{-1} t v^{-tr} . Every `v` represented by its first column
+    of its inverse which is well defined up to units of `\ZZ / N \ZZ`.
+    """
+    def __init__(self, level, reduced = True) :
+        if level == 1 :
+            ## P1List(1) does not accept 1 as an index which is what we consider the
+            ## unit element in GL(2, ZZ)
+            raise NotImplementedError( "Level must not be 1")
+        self.__level = level
+        self.__reduced = reduced
+        
+        self.__p1list = P1List(level)
+
+    def ngens(self) :
+        ## FIXME: This is not correct if N != 1
+        return 4 if not self.__reduced else 3
+    
+    def gen(self, i = 0) :
+        ## FIXME: This is not correct if N != 1
+        if i == 0 :
+            return ((1, 0, 0), 0)
+        elif i == 1 :
+            return ((0, 0, 1), 0)
+        elif i == 2 :
+            return ((1, 1, 1), 0)
+        elif not self.__reduced and i == 3 :
+            return ((1, -1, 1), 0)
+        
+        raise ValueError, "Generator not defined"
+    
+    def gens(self) :    
+        return [self.gen(i) for i in xrange(self.ngens())]
+
+    def is_commutative(self) :
+        return True
+    
+    def monoid(self) :
+        return ParamodularFormD2Indices_discriminant(self.__level, False) 
+
+    def group(self) :
+        return "GL(2,ZZ)_0 (%s)" % (self.__level,)
+    
+    def level(self) :
+        return self.__level
+    
+    def _p1list(self) :
+        return self.__p1list
+        
+    def is_monoid_action(self) :
+        """
+        True if the representation respects the monoid structure.
+        """
+        return True
+    
+    def filter(self, disc) :
+        return ParamodularFormD2Filter_discriminant(disc, self.__level, self.__reduced)
+        
+    def filter_all(self) :
+        return ParamodularFormD2Filter_discriminant(infinity, self.__level, self.__reduced)
+    
+    def zero_filter(self) :
+        return ParamodularFormD2Filter_discriminant(0, self.__level, self.__reduced) 
+    
+    def minimal_composition_filter(self, ls, rs) :
+        if len(ls) == 0 or len(rs) == 0 :
+            return ParamodularFormD2Filter_discriminant(0, self.__reduced)
+        
+        if len(ls) == 1 and ls[0][0] == (0,0,0) :
+            return ParamodularFormD2Filter_discriminant(
+                    min(4*self.__level*a*c - b**2 for (a,b,c) in rs),
+                    self.__reduced)
+        if len(rs) == 1 and rs[0][0] == (0,0,0) :
+            return ParamodularFormD2Filter_discriminant(
+                    min(4*self.__level*a*c - b**2 for (a,b,c) in ls),
+                    self.__reduced)
+        
+        raise ArithmeticError, "Discriminant filter does not " + \
+                               "admit minimal composition filters"
+        
+    def _reduction_function(self) :
+        return lambda s: reduce_GL(s, self.__p1list)
+    
+    def reduce(self, s) :
+        return reduce_GL(s, self.__p1list)
+  
+    def decompositions(self, s) :
+        ((a, b, c), l) = s
+        
+        #                  r t r^tr = t_1 + t_2
+        # \Rightleftarrow  t = r t_1 r^tr + r t_2 r^tr
+        for a1 in xrange(a + 1) :
+            a2 = a - a1
+            for c1 in xrange(c + 1) :
+                c2 = c - c1
+                
+                B1 = isqrt(4*a1*c1)
+                B2 = isqrt(4*a2*c2)
+                for b1 in xrange(max(-B1, b - B2), min(B1 + 1, b + B2 + 1)) :
+                    h1 = apply_GL_to_form(self.__p1list[l], (a1, b1, c1))
+                    h2 = apply_GL_to_form(self.__p1list[l], (a2, b - b1, c2))
+                    if h1[2] % self.__level == 0 and h2[2] % self.__level == 0:
+                        yield ((h1, 1), (h2,1))
+        
+        raise StopIteration
+    
+    def zero_element(self) :
+        return ((0,0,0), 1)
+
+    def __contains__(self, x) :
+        return isinstance(x, tuple) and len(x) == 2 and \
+               isinstance(x[0], tuple) and len(x[0]) == 3 and \
+               all(isinstance(e, (int,Integer)) for e in x[0]) and \
+               isinstance(x[1], (int,Integer))
+        
+    def __cmp__(self, other) :
+        c = cmp(type(self), type(other))
+        
+        if c == 0 :
+            c = cmp(self.__level, other.__level)
+        if c == 0 :
+            c = cmp(self.__reduced, other.__reduced)
+            
+        return c
+    
+    def __hash__(self) :
+        return xor(hash(self.__level), hash(self.__reduced))
+    
+    def _repr_(self) :
+        if self.__reduced :
+            return "Paramodular indices for level %s" % (self.__level,)
+        else :
+            return "Quadratic forms over ZZ with P^1(ZZ/%s ZZ) structure" % (self.__level,)
+            
+    def _latex_(self) :
+        if self.__reduced :
+            return "Paramodular indices for level %s" % (latex(self.__level),)
+        else :
+            return "Quadratic forms over $\ZZ$ with $\mathbb{P}^1(\ZZ/%s \ZZ)$ structure" \
+                    % (latex(self.__level),)
+
+#===============================================================================
+# ParamodularFormD2Filter_discriminant
+#===============================================================================
+
+class ParamodularFormD2Filter_discriminant ( SageObject ) :
+    def __init__(self, disc, level, reduced = True) :
+        self.__level = level
+        
+        if isinstance(disc, ParamodularFormD2Filter_discriminant) :
+            disc = disc.index()
+
+        if disc is infinity :
+            self.__disc = disc
+        else :
+            oDmod = (-disc + 1) % (4 * level)
+            Dmod = oDmod
+            while Dmod > 0 :
+                if not Mod(Dmod, 4 * level) :
+                    Dmod = Dmod - 1
+                else :
+                    break
+            
+            self.__disc = disc - (oDmod - Dmod)
+             
+        self.__reduced = reduced
+        
+        self.__p1list = P1List(level)
+
+    def filter_all(self) :
+        return ParamodularFormD2Filter_discriminant(infinity, self.__level, self.__reduced)
+    
+    def zero_filter(self) :
+        return ParamodularFormD2Filter_discriminant(0, self.__level, self.__reduced) 
+
+    def is_infinite(self) :
+        return self.__disc is infinity
+    
+    def is_all(self) :
+        return self.is_infinite()
+
+    def level(self) :
+        return self.__level
+        
+    def index(self) :
+        return self.__disc
+
+    def _p1list(self) :
+        return self.__p1list
+
+    def _contained_trace_bound(self) :
+        if self.index() == 3 :
+            return 2
+        else :
+            return 2 * self.index() // 3
+
+    def _contained_discriminant_bound(self) :
+        return self.index()
+    
+    def _enveloping_discriminant_bound(self) :
+        return self.index()
+    
+    def is_reduced(self) :
+        return self.__reduced
+    
+    def __contains__(self, f) :
+        """
+        Check whether an index has discriminant less than ``self.__index`` and 
+        whether its bottom right entry is divisible by ``self.__level``.
+        """
+        if self.__disc is infinity :
+            return True
+        
+        (s, l) = f
+
+        (a, b, c) = apply_GL_to_form(self.__p1list[l], s)
+        if not c % self.__level == 0 :
+            return False
+        
+        disc = 4*a*c - b**2
+        if disc == 0 :
+            return gcd([a,b,c]) < self._indefinite_content_bound()
+        else :
+            return disc < self.__disc
+    
+    def _indefinite_content_bound(self) :
+        r"""
+        Return the maximal trace for semi definite forms, which are considered
+        to be below this precision.
+        
+        NOTE:
+        
+            The optimal value would be `\sqrt{D / 3}`, but this leads to very small precisions
+            on converting to trace bounds.
+        """
+        return 2 * self.index() // 3
+    
+    def __iter__(self) :
+        return itertools.chain( self.iter_positive_forms(),
+                                self.iter_indefinite_forms() )
+        
+    def iter_positive_forms(self) :
+        if self.__disc is infinity :
+            raise ValueError, "infinity is not a true filter index"
+        
+        if self.__reduced :
+            for (l, (u,x)) in enumerate(self.__p1list) :
+                if u == 0 :
+                    for a in xrange(self.__level, isqrt(self.__disc // 4) + 1, self.__level) :
+                        for b in xrange(a+1) :
+                            for c in xrange(a, (b**2 + (self.__disc - 1))//(4*a) + 1) :
+                                yield ((a,b,c), l)
+                else :
+                    for a in xrange(1, isqrt(self.__disc // 3) + 1) :
+                        for b in xrange(a+1) :
+                            ## We need x**2 * a + x * b + c % N == 0
+                            h = (-((x**2 + 1) * a + x * b)) % self.__level
+                            for c in xrange( a + h,
+                                             (b**2 + (self.__disc - 1))//(4*a) + 1, self.__level ) :
+                                yield ((a,b,c), l)
+        #! if self.__reduced
+        else :
+            maxtrace = floor(self.__disc / Integer(3) + sqrt(self.__disc / Integer(3)))
+            for (l, (u,x)) in enumerate(self.__p1list) :
+                if u == 0 :
+                    for a in xrange(self.__level, maxtrace + 1, self.__level) :
+                        for c in xrange(1, maxtrace - a + 1) :
+                            Bu = isqrt(4*a*c - 1)
+        
+                            di = 4*a*c - self.__disc
+                            if di >= 0 :
+                                Bl = isqrt(di) + 1 
+                            else :
+                                Bl = 0
+                            
+                            for b in xrange(-Bu, -Bl + 1) :
+                                yield ((a,b,c), l)
+                            for b in xrange(Bl, Bu + 1) :
+                                yield ((a,b,c), l)
+                else :
+                    for a in xrange(1, maxtrace + 1) :
+                        for c in xrange(1, maxtrace - a + 1) :
+                            Bu = isqrt(4*a*c - 1)
+        
+                            di = 4*a*c - self.__disc
+                            if di >= 0 :
+                                Bl = isqrt(di) + 1 
+                            else :
+                                Bl = 0
+                            
+                            h = (-x * a - int(Mod(x, self.__level)**-1) * c - Bu) % self.__level \
+                                if x != 0 else \
+                                (-Bu) % self.__level
+                            for b in xrange(-Bu + self.__level - h, -Bl + 1, self.__level) :
+                                yield ((a,b,c), l)
+                            h = (-x * a - int(Mod(x, self.__level)**-1) * c + Bl) % self.__level \
+                                if x !=0 else \
+                                Bl % self.__level
+                            for b in xrange(Bl + self.__level - h, Bu + 1, self.__level) :
+                                yield ((a,b,c), l)
+        #! else self.__reduced
+        
+        raise StopIteration
+    
+    def iter_indefinite_forms(self) :
+        if self.__disc is infinity :
+            raise ValueError, "infinity is not a true filter index"
+        
+        
+        if self.__reduced :
+            for (l, (u,_)) in enumerate(self.__p1list) :
+                if u == 0 :
+                    for c in xrange(self._indefinite_content_bound()) :
+                        yield ((0,0,c), l)
+                else :
+                    for c in xrange(0, self._indefinite_content_bound(), self.__level) :
+                        yield ((0,0,c), l)
+        else :
+            raise NotImplementedError
+        
+        raise StopIteration
+
+    def _iter_positive_forms_with_content_and_discriminant(self) :
+        if self.__disc is infinity :
+            raise ValueError, "infinity is not a true filter index"
+        
+        if self.__reduced :
+            for (l, (u,x)) in enumerate(self.__p1list) :
+                if u == 0 :
+                    for a in xrange(self.__level, isqrt(self.__disc // 4) + 1, self.__level) :
+                        frpa = 4 * a
+                        for b in xrange(a+1) :
+                            g = gcd(a // self.__level,b)
+                            bsq = b**2
+
+                            for c in xrange(a, (b**2 + (self.__disc - 1))//(4*a) + 1) :
+                                yield (((a,b,c), l), gcd(g,c), frpa*c - bsq)
+                else :
+                    for a in xrange(1, isqrt(self.__disc // 3) + 1) :
+                        frpa = 4 * a
+                        for b in xrange(a+1) :
+                            g = gcd(a, b)
+                            bsq = b**2
+                                                        
+                            ## We need x**2 * a + x * b + c % N == 0
+                            h = (-((x**2 + 1) * a + x * b)) % self.__level
+                            for c in xrange( a + h,
+                                             (b**2 + (self.__disc - 1))//(4*a) + 1, self.__level ) :
+                                yield (((a,b,c), l), gcd(g,(x**2 * a + x * b + c) // self.__level), frpa*c - bsq)
+        #! if self.__reduced
+        else :
+            raise NotImplementedError
+        
+        raise StopIteration
+    
+    def _hecke_operator(self, n) :
+        if gcd(n, self.__level) != 1 :
+            raise NotImplementedError
+        else :
+            return ParamodularFormD2Filter_discriminant(self.__disc // n**2, self.__level, self.__reduced) 
+    
+    def __cmp__(self, other) :
+        c = cmp(type(self), type(other))
+        
+        if c == 0 :
+            c = cmp(self.__level, other.__level)
+        if c == 0 :
+            c = cmp(self.__reduced, other.__reduced)
+        if c == 0 :
+            c = cmp(self.__disc, other.__disc)
+            
+        return c
+
+    def __hash__(self) :
+        return reduce(xor, map(hash, [type(self), self.__level, self.__disc]))
+                   
+    def _repr_(self) :
+        return "Discriminant filter (%s) for paramodular forms of level %s " \
+                 % (self.__disc, self.__level)
+    
+    def _latex_(self) :
+        return "Discriminant filter (%s) for paramodular forms of level %s " \
+                 % (latex(self.__disc), latex(self.__level))
+
+
+class ParamodularFormD2Filter_trace (SageObject) :
+    def __init__(self, precision, level, reduced = True) :
+        self.__level = level
+        
+        if isinstance(precision, ParamodularFormD2Filter_trace) :
+            precision = precision.index()
+        elif isinstance(precision, ParamodularFormD2Filter_discriminant) :
+            if precision.index() is infinity :
+                precision = infinity
+            else :
+                precision = isqrt(precision.index() - 1) + 1 
+
+        self.__trace = precision
+        self.__reduced = reduced
+        self.__p1list = P1List(level)
+
+    def filter_all(self) :
+        return ParamodularFormD2Filter_trace(infinity, self.__level, self.__reduced)
+    
+    def zero_filter(self) :
+        return ParamodularFormD2Filter_trace(0, self.__level, self.__reduced) 
+
+    def is_infinite(self) :
+        return self.__trace is infinity
+    
+    def is_all(self) :
+        return self.is_infinite()
+
+    def is_all(self) :
+        return self.is_infinite()
+
+    def level(self) :
+        return self.__level
+    
+    def index(self) :
+        return self.__trace
+
+    def _contained_trace_bound(self) :
+        return self.index()
+        
+    def _contained_discriminant_bound(self) :
+        return floor( (self.index() / ( Integer(1) + self.__level + self.__level**2) )**2 )
+    
+    def _enveloping_discriminant_bound(self) :
+        return ceil(3 * self.index() / Integer(2))
+    
+    def is_reduced(self) :
+        return self.__reduced
+    
+    def __contains__(self, f) :
+        r"""
+        Check whether an index has discriminant less than ``self.__index`` and 
+        whether its bottom right entry is divisible by ``self.__level``.
+        """
+        if self.__disc is infinity :
+            return True
+        
+        (s, l) = f
+
+        (a, _, c) = apply_GL_to_form(self.__p1list[l], s)
+        if not c % self.__level == 0 :
+            return False
+
+        return a + c < self.index()
+    
+    def __iter__(self) :
+        return itertools.chain( self.iter_positive_forms(),
+                                self.iter_indefinite_forms() )
+        
+    def iter_positive_forms(self) :
+        if self.__disc is infinity :
+            raise ValueError, "infinity is not a true filter index"
+        
+        if self.__reduced :
+            for (l, (u,x)) in enumerate(self.__p1list) :
+                if u == 0 :
+                    for a in xrange(self.__level, self.__trace, self.__level) :
+                        for c in xrange(a, self.__trace - a) :
+                            for b in xrange( 2 * isqrt(a * c - 1) + 2 if a*c != 1 else 1,
+                                             2 * isqrt(a * c) ) :
+                                yield ((a,b,c), l)
+                else :
+                    for a in xrange(1, self.__trace) :
+                        for b in xrange(a+1) :
+                            ## We need x**2 * a + x * b + c % N == 0
+                            h = ((x**2 + 1) * a + x * b) % self.__level
+                            if x == 0 and h == 0 : h = 1
+                            for c in xrange( h, self.__trace - x * b - (x**2  + 1) * a, self.__level ) :
+                                yield ((a,b,c), l)
+        #! if self.__reduced
+        else :
+            for (l, (u,x)) in enumerate(self.__p1list) :
+                if u == 0 :
+                    for a in xrange(self.__level, self.__trace, self.__level) :
+                        for c in xrange(1, self.__trace - a) :
+                            for b in xrange( 2 * isqrt(a * c - 1) + 2 if a*c != 1 else 1,
+                                             2 * isqrt(a * c) ) :
+                                yield ((a,b,c), l)
+                else :
+                    for a in xrange(1, self.__trace) :
+                        for c in xrange(self.__level, self.__trace - a, self.__level) :
+                            for b in xrange( 2 * isqrt(a * c - 1) + 2 if a*c != 1 else 1,
+                                             2 * isqrt(a * c) ) :
+                                yield ((a, b - 2 * x * a, c - x * b - x**2 * a), l)
+        #! else self.__reduced
+        
+        raise StopIteration
+    
+    def iter_indefinite_forms(self) :
+        if self.__disc is infinity :
+            raise ValueError, "infinity is not a true filter index"
+        
+        if self.__reduced :
+            for (l, (u,_)) in enumerate(self.__p1list) :
+                if u == 0 :
+                    for c in xrange(self.__trace) :
+                        yield ((0,0,c), l)
+                else :
+                    for c in xrange(0, self.__trace, self.__level) :
+                        yield ((0,0,c), l)
+        else :
+            raise NotImplementedError
+        
+        raise StopIteration
+    
+    def _hecke_operator(self, n) :
+        raise ValueError( "Non-GL(2, ZZ) invariant filter does not admit Hecke action.\n" +
+                          "Use conversion to discriminant filters first.")
+        
+    def __cmp__(self, other) :
+        c = cmp(type(self), type(other))
+        
+        if c == 0 :
+            c = cmp(self.__level, other.__level)
+        if c == 0 :
+            c = cmp(self.__reduced, other.__reduced)
+        if c == 0 :
+            c = cmp(self.__trace, other.__trace)
+            
+        return c
+
+    def __hash__(self) :
+        return reduce(xor, map(hash, [type(self), self.__level, self.__trace]))
+                   
+    def _repr_(self) :
+        return "Trace filter (%s) for paramodular forms of level %s " \
+                 % (self.__disc, self.__level)
+    
+    def _latex_(self) :
+        return "Trace filter (%s) for paramodular forms of level %s " \
+                 % (latex(self.__disc), latex(self.__level))
+
+#===============================================================================
+# SiegelModularFormG2FourierExpansionRing
+#===============================================================================
+
+def ParamodularFormD2FourierExpansionRing(K, level) :
+    
+    R = EquivariantMonoidPowerSeriesRing(
+         ParamodularFormD2Indices_discriminant(level),
+         TrivialCharacterMonoid("GL(2,ZZ)_0 (%s)" % (level,), ZZ),
+         TrivialRepresentation("GL(2,ZZ)_0 (%s)" % (level,), K) )
+
+#    R._set_reduction_function(reduce_GL)
+
+#    if K is ZZ :
+#        R._set_multiply_function(mult_coeff_int)
+#    else :
+#        R._set_multiply_function(mult_coeff_generic)
+        
+    return R

--- a/psage/modform/paramodularforms/paramodularformd2_fourierexpansion_cython.pyx
+++ b/psage/modform/paramodularforms/paramodularformd2_fourierexpansion_cython.pyx
@@ -1,0 +1,182 @@
+r"""
+Functions for reduction of Fourier indices and for multiplication of
+paramodular modular forms.
+
+AUTHORS:
+
+- Martin Raum (2010 - 04 - 09) Intitial version
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+include "interrupt.pxi"
+include "stdsage.pxi"
+include "cdefs.pxi"
+
+include 'sage/ext/gmp.pxi'
+
+from sage.rings.arith import gcd
+from sage.rings.integer cimport Integer
+
+## [a,b,c] a quadratic form; (u,x) an element of P1(ZZ/pZZ)
+cdef struct para_index :
+    int a
+    int b
+    int c
+    int u
+    int x 
+
+#####################################################################
+#####################################################################
+#####################################################################
+
+cdef dict _inverse_mod_N_cache = dict()
+
+#####################################################################
+#####################################################################
+#####################################################################
+
+#===============================================================================
+# apply_GL_to_form
+#===============================================================================
+
+cpdef apply_GL_to_form(g, s) :
+    """
+    Return g s g^\tr if s is written as a matrix [a, b/2, b/2, c].
+    """
+    cdef int a, b, c,  u, x
+
+    (u, x) = g
+    (a,b,c) = s
+    
+    if u == 0 :
+        return (c, b, a)
+    else :
+        return (a, b + 2*x*a, c + b*x + x**2 * a)
+    
+#===============================================================================
+# reduce
+#===============================================================================
+
+def reduce_GL(index, p1list) :
+    r"""
+    A reduced form `((a,b,c), l)` satisfies `0 \le b \le a \le c`.
+    """
+    cdef int a, b, c, l, u, x, N
+    cdef para_index res
+    
+    ((a,b,c), l) = index
+    (u, x) = p1list[l]
+    N = p1list.N()
+
+    res = _reduce_ux(a, b, c, u, x, N)
+    
+    ## We use an exceptional rule for N = 1, since otherwise l = -1
+    if N == 1 :
+        return (((res.a, res.b, res.c), 0), 0)
+    else :
+        return (((res.a, res.b, res.c), p1list.index(res.u,res.x)), 0)
+
+#===============================================================================
+# _reduce_ux
+#===============================================================================
+
+cdef para_index _reduce_ux(int a, int b, int c, int u, int x, int N) :
+    r"""
+    We reduce the pair `(t, v)` by right action of `GL_2(ZZ)`.
+    v is a left coset representative with respect to `(GL_2(ZZ))_0 (N)`.
+    `(x, u)` is the second row of `v`. 
+    
+    NOTE:
+        The quadratic form is reduced following Algorithm 5.4.2 found in Cohen's
+        Computational Algebraic Number Theory.
+    """
+    cdef para_index res
+    cdef int twoa, q, r
+    cdef int tmp
+
+    
+    global _inverse_mod_N_cache
+    if not N in _inverse_mod_N_cache :
+        invN = PY_NEW(dict)
+        
+        for i in xrange(N) :
+            if gcd(i,N) == 1 :
+                invN[i] = Integer(i).inverse_mod(N)
+        _inverse_mod_N_cache[N] = invN
+        
+    inverse_mod_N = _inverse_mod_N_cache[N] 
+
+    if b < 0 :
+        b = -b
+        
+        if u != 0 :
+            x = (-x) % N
+        
+    while ( b > a or a > c ) :
+        twoa = 2 * a
+        
+        #if b not in range(-a+1,a+1):
+        if b > a :
+            ## apply Euclidean step (translation)
+            q = b // twoa #(2*a)
+            r = b % twoa  #(2*a)
+            if r > a :
+                ## want (quotient and) remainder such that -a < r <= a
+                r = r - twoa  # 2*a;
+                q = q + 1
+            c = c - b*q + a*q*q
+            b = r
+            
+            if u != 0 :
+                x = (x + q) % N
+            
+        ## apply symmetric step (reflection) if necessary
+        if a > c:
+            #(a,c) = (c,a)
+            tmp = c
+            c = a
+            a = tmp
+            
+            if u == 0 :
+                u = 1
+                x = 0
+            elif x == 0 :
+                u = 0
+                x = 1
+            else :
+                x = (-inverse_mod_N[x]) % N
+
+        #b = abs(b)
+        if b < 0:
+            b = -b
+            
+            if u != 0 :
+                x = (-x) % N
+        ## iterate
+    ## We're finished! Return the GL2(ZZ)-reduced form (a,b,c):
+
+    res.a = a
+    res.b = b
+    res.c = c
+    res.u = u
+    res.x = x
+            
+    return res

--- a/psage/modform/paramodularforms/paramodularformd2_heckeaction.py
+++ b/psage/modform/paramodularforms/paramodularformd2_heckeaction.py
@@ -1,0 +1,167 @@
+r"""
+The Hecke action for paramodular forms of degree 2.
+
+AUTHOR :
+    -- Martin Raum (2010 - 05 - 04) Initial version, based on Siegel modular forms case.
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.paramodularforms.paramodularformd2_fourierexpansion_cython import apply_GL_to_form 
+from sage.misc.cachefunc import cached_method
+from sage.misc.latex import latex
+from sage.modular.modsym.p1list import P1List
+from sage.rings.arith import gcd
+from sage.rings.integer import Integer
+from sage.structure.sage_object import SageObject
+from psage.modform.paramodularforms import siegelmodularformg2_misc_cython
+
+_paramodularformd2_heckeoperator_cache = dict()
+
+#===============================================================================
+# SiegelModularFormG2FourierExpansionHeckeAction
+#===============================================================================
+
+def ParamodularFormD2FourierExpansionHeckeAction( n ) :
+    global _paramodularformd2_heckeoperator_cache
+        
+    try :
+        return _paramodularformd2_heckeoperator_cache[n]
+    except KeyError :
+        A = ParamodularFormD2FourierExpansionHeckeAction_class(n)
+        _paramodularformd2_heckeoperator_cache[n] = A
+        
+        return A
+
+#===============================================================================
+# ParamodularFormD2FourierExpansionHeckeAction_class
+#===============================================================================
+
+class ParamodularFormD2FourierExpansionHeckeAction_class (SageObject):
+    r"""
+    Implements a Hecke operator acting on paramodular modular forms of degree 2.
+    """
+
+    def __init__(self, n):
+        self.__l = n
+        
+        self.__l_divisors = siegelmodularformg2_misc_cython.divisor_dict(n + 1)
+
+    def eval(self, expansion, weight = None) :
+        if weight is None :
+            try :
+                weight = expansion.weight()
+            except AttributeError :
+                raise ValueError, "weight must be defined for the Hecke action"
+        
+        precision = expansion.precision()
+        if precision.is_infinite() :
+            precision = expansion._bounding_precision()
+        else :
+            precision = precision._hecke_operator(self.__l)
+        characters = expansion.non_zero_components()
+        expansion_level = precision.level()
+        
+        if gcd(expansion_level, self.__l) != 1 :
+            raise ValueError, "Level of expansion and of Hecke operator must be coprime."
+        
+        hecke_expansion = dict()
+        for ch in characters :
+            hecke_expansion[ch] = dict( (k, self.hecke_coeff(expansion, ch, k, weight, expansion_level))
+                                        for k in precision )
+        
+        result = expansion.parent()._element_constructor_(hecke_expansion)
+        result._set_precision(expansion.precision()._hecke_operator(self.__l))
+        
+        return result
+        
+    # TODO : reimplement in cython
+    def hecke_coeff(self, expansion, ch, ((a,b,c), l), k, N) :
+        r"""
+        Computes the coefficient indexed by $(a,b,c)$ of $T(\ell) (F)$
+        """
+        character_eval = expansion.parent()._character_eval_function()
+        
+        if N == 1 :
+            ## We have to consider that now (a,b,c) -> (c, b, a)
+            raise NotImplementedError
+
+        (a, b, c) = apply_GL_to_form(expansion.precision()._p1list()[l], (a, b, c))
+        
+        ell = self.__l
+        coeff = 0
+        for t1 in self.__l_divisors[ell]:
+            for t2 in self.__l_divisors[t1]:
+                for V in self.get_representatives(t1/t2, N):
+                    (aprime, bprime, cprime) = self.change_variables(V,(a,b,c))
+                    if aprime % t1 == 0 and bprime % t2 == 0 and cprime % (N * t2) == 0:
+                        coeff = coeff + character_eval(V, ch) * t1**(k-2)*t2**(k-1) \
+                                        * expansion[( ch, (( (ell*aprime) //t1**2,
+                                                             (ell*bprime) //t1//t2,
+                                                             (ell*cprime) //t2**2 ), 1) )]
+
+        return coeff
+
+    @cached_method
+    def get_representatives( self, t, N) :
+        r"""
+        A helper function used in hecke_coeff that computes the right
+        coset representatives of $\Gamma^0(t) \cap \Gamma_0(N) \ Gamma_0(N)$ where
+        $\Gamma^0(t)$ is the subgroup of $SL(2,Z)$ where the upper right hand
+        corner is divisible by $t$.
+
+        NOTE
+            We use the bijection $\Gamma^0(t)\SL(2,Z) \rightarrow P^1(\Z/t\Z)$
+            given by $A \mapsto [1:0]A$.
+        """
+        if t == 1 : return [(1,0,0,1)]
+        
+        rep_list = []
+        
+        for (x,y) in P1List(t):
+            ## we know that (N, x, y) = 1
+            N1 = gcd(N, x)
+            if N1 != 1 :
+                x = x + t * N // N1
+
+            ## we calculate a pair c,d satisfying a minimality condition
+            ## to make later multiplications cheaper
+            (_, d, c) = Integer(x)._xgcd(Integer(N * y), minimal=True)
+            
+            #print (x, y, -N * c, d)
+            rep_list.append((x, y, -N * c, d))
+                
+        return rep_list
+
+    @staticmethod
+    def change_variables((a,b,c,d), (n,r,m)):
+        r"""
+        A helper function used in hecke_coeff that computes the
+        quadratic form [nprime,rprime,mprime] given by $Q((x,y) V)$
+        where $Q=[n,r,m]$ and $V$ is a 2 by 2 matrix given by (a,b,c,d)
+        """        
+        return ( n*a**2 + r*a*b + m*b**2, 2*(n*a*c + m*b*d) + r*(a*d + c*b), \
+                 n*c**2 + r*c*d + m*d**2 )
+
+    def _repr_(self) :
+        return '%s-th Hecke operator for paramodular forms' % self.__l
+
+    def _latex_(self) :
+        return latex(self.__n) + '-th Hecke operator for paramodular forms'

--- a/psage/modform/paramodularforms/paramodularformd2_types.py
+++ b/psage/modform/paramodularforms/paramodularformd2_types.py
@@ -1,0 +1,376 @@
+r"""
+Types for paramodular forms of fixed level and weight.
+
+AUTHOR :
+    -- Martin Raum (2010 - 04 - 15) Initial version.
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.fourier_expansion_framework.gradedexpansions.expansion_module import ExpansionModule
+from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import TrivialGrading
+from psage.modform.fourier_expansion_framework.modularforms.modularform_ambient import ModularFormsModule_generic
+from psage.modform.fourier_expansion_framework.modularforms.modularform_types import ModularFormType_abstract
+from psage.modform.jacobiforms.jacobiformd1nn_types import JacobiFormD1NN_Gamma
+from operator import xor
+from psage.modform.paramodularforms.paramodularformd2_element import ParamodularFormD2_classical
+from psage.modform.paramodularforms.paramodularformd2_fegenerators import gritsenko_products
+from psage.modform.paramodularforms.paramodularformd2_fourierexpansion import ParamodularFormD2Filter_discriminant,\
+    ParamodularFormD2FourierExpansionRing
+from psage.modform.paramodularforms.paramodularformd2_heckeaction import ParamodularFormD2FourierExpansionHeckeAction
+from psage.modform.paramodularforms.paramodularformd2_fegenerators import symmetrised_siegel_modular_forms
+from sage.categories.number_fields import NumberFields
+from sage.misc.cachefunc import cached_method
+from sage.rings.arith import kronecker_symbol
+from sage.rings.integer import Integer
+from sage.rings.integer_ring import ZZ
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.power_series_ring import PowerSeriesRing
+from sage.rings.rational_field import QQ
+from sage.structure.sequence import Sequence
+from sage.modular.all import ModularForms
+
+#===============================================================================
+# ParamodularFormsD2
+#===============================================================================
+
+_paramodularforms_cache = dict()
+
+def ParamodularFormsD2(A, type, precision, *args, **kwds) :
+    global _paramodularforms_cache
+    if isinstance(precision, (int, Integer)) :
+        precision = ParamodularFormD2Filter_discriminant(precision, type.level()) 
+    k = (A, type, precision)
+    
+    try :
+        return _paramodularforms_cache[k]
+    except KeyError :
+        if isinstance(type,ParamodularFormD2_Gamma) :
+            M = ModularFormsModule_generic(A, type, precision)
+        else :
+            raise TypeError, "%s must be a paramodular form type" % (type,)
+        
+        _paramodularforms_cache[k] = M
+        return M
+
+#===============================================================================
+# ParamodularFormD2_Gamma
+#===============================================================================
+
+class ParamodularFormD2_Gamma ( ModularFormType_abstract ) :
+    """
+    Type of paramodular forms of degree 2. 
+    """
+    def __init__(self, level, weight) :
+        if weight % 2 != 0 :
+            raise NotImplementedError, "Only even weight forms are implemented."
+  
+        if level != 1 and not Integer(level).is_prime() :
+            raise NotImplementedError, "Only prime level or level 1 is implemented."
+  
+        self.__level = Integer(level)
+        self.__weight = weight        
+    
+    def level(self) :
+        return self.__level
+    
+    def _ambient_construction_function(self) :
+        return ParamodularFormsD2
+    
+    def _ambient_element_class(self) :
+        return ParamodularFormD2_classical
+    
+    def group(self) :
+        return "\Gamma_2 ^para"
+    
+    def _rank(self, K) :
+        """
+        Return the dimension of the level N space of given weight. 
+        """
+        if not K is QQ :
+            raise NotImplementedError
+        
+        if not self.__level.is_prime() :
+            raise NotImplementedError
+    
+        if self.__weight % 2 != 0 :
+            raise NotImplementedError( "Only even weights available")
+    
+        N = self.__level
+        
+        if N == 1 :
+            ## By Igusa's theorem on the generators of the graded ring
+            P = PowerSeriesRing(ZZ, 't')
+            t = P.gen(0)
+                                
+            dims = 1 / ((1 - t**4) * (1 - t**6) * (1 - t**10) * (1 - t**12)).add_bigoh(self.__weight + 1)
+            
+            return dims[self.__weight]
+        if N == 2 :
+            ## As in Ibukiyama, Onodera - On the graded ring of modular forms of the Siegel
+            ## paramodular group of level 2, Proposition 2
+            P = PowerSeriesRing(ZZ, 't')
+            t = P.gen(0)
+                                
+            dims = ((1 + t**10) * (1 + t ** 12) * (1 + t**11))
+            dims = dims / ((1 - t**4) * (1 - t**6) * (1 - t**8) * (1 - t**12)).add_bigoh(self.__weight + 1)
+            
+            return dims[self.__weight]
+        if N == 3 :
+            ## By Dern, Paramodular forms of degree 2 and level 3, Corollary 5.6
+            P = PowerSeriesRing(ZZ, 't')
+            t = P.gen(0)
+            
+            dims = ((1 + t**12) * (1 + t**8 + t**9 + t**10 + t**11 + t**19))
+            dims = dims / ((1 - t**4) * (1 - t**6)**2 * (1 - t**12)).add_bigoh(self.__weight + 1)
+            
+            return dims[self.__weight]
+        if N == 5 :
+            ## By Marschner, Paramodular forms of degree 2 with particular emphasis on level t = 5,
+            ## Corollary 7.3.4. PhD thesis electronically available via the library of
+            ## RWTH University, Aachen, Germany  
+            P = PowerSeriesRing(ZZ, 't')
+            t = P.gen(0)
+            
+            dims =   t**30 + t**24 + t**23 + 2*t**22 + t**21 + 2*t**20 + t**19 + 2*t**18 \
+                   + 2*t**16 + 2*t**14 + 2*t**12 + t**11 + 2*t**10 + t**9 + 2*t**8 + t**7 + t**6 + 1
+            dims = dims / ((1 - t**4) * (1 - t**5) * (1 - t**6) * (1 - t**12)).add_bigoh(self.__weight + 1)
+            
+            return dims[self.__weight]
+        
+        if self.__weight == 2 :
+            ## There are only cuspforms, since there is no elliptic modular form
+            ## of weight 2.
+            if N < 277 :
+                ## Poor, Yuen - Paramodular cusp forms tells us that all forms are
+                ## Gritsenko lifts
+                return JacobiFormD1NN_Gamma(self.__level, 2)._rank(QQ)
+
+            raise NotImplementedError
+        elif self.__weight == 4 :
+            ## This is the formula cited by Poor and Yuen in Paramodular cusp forms
+            cuspidal_dim =  Integer(   (N**2 - 143) / Integer(576) + N / Integer(8)
+                                     + kronecker_symbol(-1, N) * (N - 12) / Integer(96)
+                                     + kronecker_symbol(2, N) / Integer(8)
+                                     + kronecker_symbol(3, N) / Integer(12)
+                                     + kronecker_symbol(-3, N) * N / Integer(36) )
+        else :
+            ## This is the formula given by Ibukiyama in
+            ## Relations of dimension of automorphic forms of Sp(2,R) and its compact twist Sp(2),
+            ## Theorem 4
+            p = N
+            k = self.__weight
+            
+            ## This is the reversed Ibukiyama symbol [.., .., ..; ..]
+            def ibukiyama_symbol(modulus, *args) :
+                return args[k % modulus]
+
+            ## if p == 2 this formula is wrong. If the weight is even it differs by
+            ## -3/16 from the true dimension and if the weight is odd it differs by
+            ## -1/16 from the true dimension. 
+            H1 = (p**2 + 1) * (2 * k - 2) * (2 * k - 3) * (2 * k - 4) / Integer(2**9 * 3**3 * 5)
+            H2 = (-1)**k * (2 * k - 2) * (2 * k - 4) / Integer(2**8 * 3**2) \
+                 + ( (-1)**k * (2 * k - 2) * (2 * k - 4) / Integer(2**7 * 3)
+                     if p !=2 else
+                     (-1)**k * (2 * k - 2) * (2 * k - 4) / Integer(2**9) )
+            H3 = ( ibukiyama_symbol(4, k - 2, -k + 1, -k + 2, k - 1) / Integer(2**4 * 3)
+                   if p != 3 else
+                   5 * ibukiyama_symbol(4, k - 2, -k + 1, -k + 2, k - 1) / Integer(2**5 * 3) )
+            H4 = ( ibukiyama_symbol(3, 2 * k - 3, -k + 1, -k + 2) / Integer(2**2 * 3**3)
+                   if p != 2 else
+                   5 * ibukiyama_symbol(3, 2 * k - 3, -k + 1, -k + 2) / Integer(2**2 * 3**3) )
+            H5 = ibukiyama_symbol(6, -1, -k + 1, -k + 2, 1, k - 1, k - 2) / Integer(2**2 * 3**2)
+            if p % 4 == 1 :
+                H6 = 5 * (2 * k - 3) * (p + 1) / Integer(2**7 * 3) + (-1)**k * (p + 1) / Integer(2**7)
+            elif p % 4 == 3 :
+                H6 = (2 * k - 3) * (p - 1) / Integer(2**7) + 5 * (-1)**k * (p - 1) / Integer(2**7 * 3)
+            else :
+                H6 = 3 * (2 * k - 3) / Integer(2**7) + 7 * (-1)**k / Integer(2**7 * 3)
+            if p % 3 == 1 :
+                H7 =   (2 * k - 3) * (p + 1) / Integer(2 * 3**3) \
+                     + (p + 1) * ibukiyama_symbol(3, 0, -1, 1) / Integer(2**2 * 3**3)
+            elif p % 3 == 2 :
+                H7 =   (2 * k - 3) * (p - 1) / Integer(2**2 * 3**3) \
+                     + (p - 1) * ibukiyama_symbol(3, 0, -1, 1) / Integer(2 * 3**3)
+            else :
+                H7 =   5 * (2 * k - 3) / Integer(2**2 * 3**3) \
+                     + ibukiyama_symbol(3, 0, -1, 1) / Integer(3**3)
+            H8 = ibukiyama_symbol(12, 1, 0, 0, -1, -1, -1, -1, 0, 0, 1, 1, 1) / Integer(2 * 3)
+            H9 = ( 2 * ibukiyama_symbol(6, 1, 0, 0, -1, 0, 0) / Integer(3**2)
+                   if p != 2 else
+                   ibukiyama_symbol(6, 1, 0, 0, -1, 0, 0) / Integer(2 * 3**2) )
+            H10 = (1 + kronecker_symbol(5, p)) * ibukiyama_symbol(5, 1, 0, 0, -1, 0) / Integer(5)
+            H11 = (1 + kronecker_symbol(2, p)) * ibukiyama_symbol(4, 1, 0, 0, -1) / Integer(2**3)
+            if p % 12 == 1 :
+                H12 = ibukiyama_symbol(3, 0, 1, -1) / Integer(2 * 3)
+            elif p % 12 == 11 :
+                H12 = (-1)**k / Integer(2 * 3)
+            elif p == 2 or p == 3 :
+                H12 = (-1)**k / Integer(2**2 * 3)
+            else :
+                H12 = 0
+                
+            I1 = ibukiyama_symbol(6, 0, 1, 1, 0, -1, -1) / Integer(6)
+            I2 = ibukiyama_symbol(3, -2, 1, 1) / Integer(2 * 3**2)
+            if p == 3 :
+                I3 = ibukiyama_symbol(3, -2, 1, 1)/ Integer(3**2)
+            elif p % 3 == 1 :
+                I3 = 2 * ibukiyama_symbol(3, -1, 1, 0) / Integer(3**2)
+            else :
+                I3 = 2 * ibukiyama_symbol(3, -1, 0, 1) / Integer(3**2)
+            I4 = ibukiyama_symbol(4, -1, 1, 1, -1) / Integer(2**2)
+            I5 = (-1)**k / Integer(2**3)
+            I6 = (-1)**k * (2 - kronecker_symbol(-1, p)) / Integer(2**4)
+            I7 = -(-1)**k * (2 * k - 3) / Integer(2**3 * 3)
+            I8 = -p * (2 * k - 3) / Integer(2**4 * 3**2)
+            I9 = -1 / Integer(2**3 * 3)
+            I10 = (p + 1) / Integer(2**3 * 3)
+            I11 = -(1 + kronecker_symbol(-1, p)) / Integer(8)
+            I12 = -(1 + kronecker_symbol(-3, p)) / Integer(6)
+            
+            cuspidal_dim =   H1 + H2 + H3 + H4 + H5 + H6 + H7 + H8 + H9 + H10 + H11 + H12 \
+                           + I1 + I2 + I3 + I4 + I5 + I6 + I7 + I8 + I9 + I10 + I11 + I12
+                       
+
+        mfs = ModularForms(1, self.__weight)
+        
+        return cuspidal_dim + mfs.dimension() + mfs.cuspidal_subspace().dimension()
+
+    def _gritsenko_products(self, precision = None) :
+        try :
+            if precision is None :
+                return self.__gritsenko_products
+            elif precision == self.__gritsenko_products_precision :
+                return self.__gritsenko_products
+            elif precision < self.__gritsenko_products_precision :
+                return ( self.__gritsenko_products[0],
+                         [p.truncate(precision) for p in self.__gritsenko_products[1]] )
+        except AttributeError :
+            pass
+        
+        self.__gritsenko_products = \
+          gritsenko_products(self.__level, self.__weight, self._rank(QQ), precision)
+        self.__gritsenko_products_precision = precision
+    
+        return self.__gritsenko_products
+        
+    def _symmetrised_siegel_modular_forms(self, precision = None) :
+        try :
+            if precision is None :
+                return self.__symmetrised_siegel_modular_forms
+            elif precision == self.__symmetriesed_siegel_modular_forms_precision :
+                return self.__symmetrised_siegel_modular_forms
+            elif precision < self.__symmetriesed_siegel_modular_forms_precision :
+                return [s.truncate(precision) for s in self.__symmetrised_siegel_modular_forms]
+        except AttributeError :
+            pass
+        
+        self.__symmetrised_siegel_modular_forms = \
+          symmetrised_siegel_modular_forms(self.__level, self.__weight, precision)
+        self.__symmetrised_siegel_modular_forms_precision = precision
+        
+        return self.__symmetrised_siegel_modular_forms 
+        
+    @cached_method
+    def generators(self, K, precision) :
+        if K is QQ or K in NumberFields() :
+            gps = self._gritsenko_products(precision)[1]
+            if len(gps) != self._rank(QQ) :
+                syms = self._symmetrised_siegel_modular_forms(precision)
+                em = ExpansionModule(Sequence(gps + syms, universe = ParamodularFormD2FourierExpansionRing(QQ, self.__level) ) )
+                gens = map(lambda e: e.fourier_expansion(), em.pivot_elements())
+            else :
+                gens = gps
+                            
+            if len(gens) == self._rank(QQ) :
+                return Sequence( gens, universe = ParamodularFormD2FourierExpansionRing(QQ, self.__level) )
+            
+            raise ArithmeticError, "Gritsenko products do not span this space."
+            
+        raise NotImplementedError
+    
+    def grading(self, K) :
+        if K is QQ or K in NumberFields() :
+            return TrivialGrading( self._rank(K), self.__weight )
+        
+        raise NotImplementedError
+
+    def _generator_names(self, K) :
+        if K is QQ or K in NumberFields() :
+            ## We assume that the space is spanned by Gritsenko products
+            ## Introduce new names, as soon as new cases are implemented
+            nmb_gps = len(self._gritsenko_products(None)[0])
+            return [ "GP_%s" % (i,) for i in xrange(nmb_gps)] + \
+                   [ "SymS_%s" % (i,) for i in xrange(self._rank(K) - nmb_gps) ]
+
+        raise NotImplementedError
+    
+    def _generator_by_name(self, K, name) :
+        if K is QQ or K in NumberFields() :
+            R = self.generator_relations(K).ring()
+            try :
+                return R.gen(self._generator_names(K).index(name))
+            except ValueError :
+                raise ValueError, "name %s doesn't exist for %s" % (name, K)
+        
+        raise NotImplementedError
+    
+    @cached_method
+    def generator_relations(self, K) :
+        r"""
+        An ideal I in a polynomial ring R, such that the associated module
+        is (R / I)_1. 
+        """
+        if K is QQ or K in NumberFields() :
+            R = PolynomialRing(K, self._generator_names(K))
+            return R.ideal(0)
+            
+        raise NotImplementedError
+
+    def reduce_before_evaluating(self, K) :
+        return False
+
+    def weights(self, K) :
+        """
+        A list of integers corresponding to the weights.
+        """
+        if K is QQ or K in NumberFields() :
+            return self._rank(K) * [self.__weight]
+            
+        raise NotImplementedError
+    
+    def graded_submodules_are_free(self) :
+        return True
+    
+    def _hecke_operator_class(self) :
+        return ParamodularFormD2FourierExpansionHeckeAction
+
+    def __cmp__(self, other) :
+        c = cmp(type(self), type(other))
+        
+        if c == 0 :
+            c = cmp(self.__level, other.__level)
+        if c == 0 :
+            c = cmp(self.__weight, other.__weight)
+            
+        return c
+
+    def __hash__(self) :
+        return reduce(xor, map(hash, [self.__level, self.__weight]))

--- a/psage/modform/paramodularforms/siegelmodularformg2_element.py
+++ b/psage/modform/paramodularforms/siegelmodularformg2_element.py
@@ -1,0 +1,74 @@
+r"""
+Elements of rings of Siegel modular forms of degree 2.
+
+AUTHOR:
+
+- Martin Raum (2009 - 08 - ??) Initial version.
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2009 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.fourier_expansion_framework.modularforms.modularform_element import ModularForm_generic, \
+                                             ModularFormVector_generic
+
+class SiegelModularFormG2_generic :
+
+    def is_cusp_form(self) :
+        r"""
+        Check wheater self is a cusp form or not.
+        """
+        
+        if self.parent().type().group() != "Sp(2,ZZ)" :
+            raise NotImplementedError
+        
+        try :
+            weight = self.weight() 
+        except ValueError :
+            return all([ f.is_cusp_form()
+                         for f in self.homogeneous_components().values() ])
+        
+        neccessary_precision = weight // 12 + 1 if weight % 12 != 2 \
+                                                else weight // 12
+        if self.parent().fourier_expansion_precision()._indefinite_content_bound() < neccessary_precision :
+            raise ValueError, "the parents precision doesn't suffice"
+        
+        evc = self.fourier_expansion()
+        return all([evc[(0,0,l)] == 0 for l in xrange(neccessary_precision)])
+        
+class SiegelModularFormG2_classical ( SiegelModularFormG2_generic, ModularForm_generic ) :
+
+    def is_maass_form(self) :    
+        r"""
+        Check whether self is in the Maass spezialschar.
+        """
+        hc = self.homogeneous_components()
+        if len(hc) == 0 : return True
+        if len(hc) > 1 : return False
+        
+        
+        grading = hc.keys()[0]
+        
+        ss = self.parent().graded_submodule(grading)
+
+        return ss(self) in ss.maass_space()
+
+class SiegelModularFormG2_vectorvalued ( SiegelModularFormG2_generic,
+                                         ModularFormVector_generic ) :
+    pass

--- a/psage/modform/paramodularforms/siegelmodularformg2_fegenerators.py
+++ b/psage/modform/paramodularforms/siegelmodularformg2_fegenerators.py
@@ -1,0 +1,428 @@
+r"""
+Generator functions for the fourier expansion of Siegel modular forms. 
+
+AUTHORS:
+
+- Nils-Peter Skorupa 
+  Factory function SiegelModularForm().
+  Code parts concerning the Maass lift are partly based on code
+  written by David Gruenewald in August 2006 which in turn is
+  based on the PARI/GP code by Nils-Peter Skoruppa from 2003.
+- Martin Raum (2009 - 07 - 28) Port to new framework.
+- Martin Raum (2010 - 03 - 16) Implement the vector valued case.
+
+REFERENCES:
+
+- [Sko] Nils-Peter Skoruppa, ...
+- [I-H] Tomoyoshi Ibukiyama and Shuichi Hayashida, ... 
+
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2009 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_lazyelement import EquivariantMonoidPowerSeries_lazy
+from psage.modform.paramodularforms.siegelmodularformg2_fourierexpansion import SiegelModularFormG2FourierExpansionRing
+from sage.combinat.partition import number_of_partitions
+from sage.misc.functional import isqrt
+from sage.misc.latex import latex 
+from sage.modular.modform.constructor import ModularForms
+from sage.modular.modform.element import ModularFormElement
+from sage.rings.arith import bernoulli, sigma
+from sage.rings.integer import Integer
+from sage.rings.integer_ring import ZZ
+from sage.rings.power_series_ring import PowerSeriesRing
+from sage.rings.rational_field import QQ
+from sage.structure.sage_object import SageObject
+from psage.modform.paramodularforms.siegelmodularformg2_fourierexpansion import SiegelModularFormG2Filter_discriminant
+from psage.modform.paramodularforms import siegelmodularformg2_misc_cython
+
+#===============================================================================
+# SiegelModularFormG2MaassLift
+#===============================================================================
+
+def SiegelModularFormG2MaassLift(f, g, precision, is_integral = True, weight = None) :    
+    factory = SiegelModularFormG2Factory(precision)
+    if is_integral :
+        expansion_ring = SiegelModularFormG2FourierExpansionRing(ZZ)
+    else :
+        expansion_ring = SiegelModularFormG2FourierExpansionRing(QQ)
+
+    if f == 0 :
+        fexp = lambda p : 0
+    if hasattr(f, "qexp") :
+        fexp = lambda p : f.qexp(p)
+    else :
+        fexp = f
+        
+    if g == 0 :
+        gexp = lambda p : 0
+    if hasattr(g, "qexp") :
+        gexp = lambda p : g.qexp(p)
+    else :
+        gexp = g
+    
+    if weight is None :
+        try :
+            weight = f.weight()
+        except AttributeError :
+            weight = g.weight() -2
+    
+    coefficients_factory = DelayedFactory_SMFG2_masslift( factory, fexp, gexp, weight )
+
+    return EquivariantMonoidPowerSeries_lazy(expansion_ring, precision, coefficients_factory.getcoeff)
+
+#===============================================================================
+# DelayedFactory_SMFG2_masslift
+#===============================================================================
+
+class DelayedFactory_SMFG2_masslift :
+    def __init__(self, factory, f, g, weight) :
+        self.__factory = factory
+        self.__f = f
+        self.__g = g
+        self.__weight = weight
+        
+        self.__series = None
+    
+    def getcoeff(self, key, **kwds) :
+        (_, k) = key
+        # for speed we ignore the character 
+        if self.__series is None :
+            self.__series = \
+             self.__factory.maass_form( self.__f, self.__g, self.__weight,
+                                        is_integral = True)
+             
+        return self.__series[k]
+
+#===============================================================================
+# SiegelModularFormG2Factory
+#===============================================================================
+
+_siegel_modular_form_g2_factory_cache = dict()
+
+def SiegelModularFormG2Factory(precision) :
+    if not isinstance(precision, SiegelModularFormG2Filter_discriminant) :
+        precision = SiegelModularFormG2Filter_discriminant(precision)
+    
+    global _siegel_modular_form_g2_factory_cache
+    try :
+        return _siegel_modular_form_g2_factory_cache[precision]
+    except KeyError :
+        factory = SiegelModularFormG2Factory_class(precision)
+        _siegel_modular_form_g2_factory_cache[precision] = factory
+        
+        return factory
+    
+#===============================================================================
+# SiegelModularFormG2Factory_class
+#===============================================================================
+
+class SiegelModularFormG2Factory_class( SageObject ) :
+    r"""
+    A class producing dictionarys saving fourier expansions of Siegel
+    modular forms of genus `2`.
+    """
+    
+    def __init__(self, precision) :
+        r"""
+        INPUT:
+        
+        - ``prec``  -- a SiegelModularFormPrec, which will be the precision of
+                       every object returned by an instance of this class.           
+        """
+        self.__precision = precision
+        
+        ## Conversion of power series is not expensive but powers of interger
+        ## series are much cheaper then powers of rational series
+        self._power_series_ring_ZZ = PowerSeriesRing(ZZ, 'q')
+        self._power_series_ring = PowerSeriesRing(QQ, 'q')
+    
+    def power_series_ring(self) :
+        return self._power_series_ring
+    
+    def integral_power_series_ring(self) :
+        return self._power_series_ring_ZZ
+    
+    def _get_maass_form_qexp_prec(self) :
+        r"""
+        Return the precision of eta, needed to calculate the Maass lift in
+        self.as_maass_spezial_form 
+        """
+        return ( self.__precision.discriminant() + 1)//4 + 1
+    
+    def _divisor_dict(self) :
+        r"""
+        Return a dictionary of assigning to each `k < n` a list of its divisors.
+        
+        INPUT:
+        
+        - `n`    -- a positive integer
+        """
+        try :
+            return self.__divisor_dict
+        except AttributeError :
+            self.__divisor_dict = siegelmodularformg2_misc_cython.divisor_dict(self.__precision.discriminant())
+
+            return self.__divisor_dict
+        
+    def _eta_power(self) :
+        try :
+            return self.__eta_power
+        except AttributeError :
+            qexp_prec = self._get_maass_form_qexp_prec()
+        
+            self.__eta_power = self.integral_power_series_ring() \
+                 ([number_of_partitions(n) for n in xrange(qexp_prec)], qexp_prec)**6
+                 
+            return self.__eta_power
+
+    def precision(self) :
+        return self.__precision
+    
+    def _negative_fundamental_discriminants(self) :
+        r"""
+        Return a list of all negative fundamental discriminants.
+        """
+        try :
+            return self.__negative_fundamental_discriminants
+        except AttributeError :
+            self.__negative_fundamental_discriminants = \
+             siegelmodularformg2_misc_cython.negative_fundamental_discriminants(
+                                              self.__precision.discriminant() )
+
+            return self.__negative_fundamental_discriminants
+    
+    def maass_form( self, f, g, k = None, is_integral = False) :
+        r"""
+        Return the Siegel modular form `I(f,g)` (Notation as in [Sko]).
+    
+        INPUT:
+        - `f`              -- modular form of level `1`
+        - `g`              -- cusp form of level `1` and weight = ``weight of f + 2``
+        - ``is_integral``  -- ``True`` if the result is garanteed to have integer
+                              coefficients
+        """
+        
+        ## we introduce an abbreviations
+        if is_integral :
+            PS = self.integral_power_series_ring()
+        else :
+            PS = self.power_series_ring()
+        
+        fismodular = isinstance(f, ModularFormElement)
+        gismodular = isinstance(g, ModularFormElement)
+    
+        ## We only check the arguments if f and g are ModularFormElements.
+        ## Otherwise we trust in the user 
+        if fismodular and gismodular :
+            assert( f.weight() + 2 == g.weight() | (f==0) | (g==0)), \
+                    "incorrect weights!"
+            assert( g.q_expansion(1) == 0), "second argument is not a cusp form"
+
+        qexp_prec = self._get_maass_form_qexp_prec()
+        if qexp_prec is None : # there are no forms below prec
+            return dict()
+
+        if fismodular :
+            k = f.weight()
+            if f == f.parent()(0) :
+                f = PS(0, qexp_prec)
+            else :
+                f = PS(f.qexp(qexp_prec), qexp_prec)
+        elif f == 0 :
+            f = PS(0, qexp_prec)
+        else :
+            f = PS(f(qexp_prec), qexp_prec)
+        
+        if gismodular :
+            k = g.weight() - 2
+            if g == g.parent()(0) :
+                g = PS(0, qexp_prec)
+            else :
+                g = PS(g.qexp(qexp_prec), qexp_prec)
+        elif g == 0 :
+            g = PS(0, qexp_prec)
+        else :
+            g = PS(g(qexp_prec), qexp_prec)
+                
+        if k is None :
+            raise ValueError, "if neither f nor g are not ModularFormElements " + \
+                              "you must pass k"
+            
+        fderiv = f.derivative().shift(1)
+        f *= Integer(k/2)
+        gfderiv = g - fderiv
+
+        ## Form A and B - the Jacobi forms used in [Sko]'s I map.
+        ## This is not necessary if we multiply Ifg0 and Ifg1 by etapow
+        # (A0,A1,B0,B1) = (a0*etapow, a1*etapow, b0*etapow, b1*etapow)
+    
+        ## Calculate the image of the pair of modular forms (f,g) under
+        ## [Sko]'s isomorphism I : M_{k} \oplus S_{k+2} -> J_{k,1}.
+        
+        # Multiplication of big polynomials may take > 60 GB, so wie have
+        # to do it in small parts; This is only implemented for integral
+        # coefficients.
+
+        """
+        Create the Jacobi form I(f,g) as in [Sko].
+    
+        It suffices to construct for all Jacobi forms phi only the part
+        sum_{r=0,1;n} c_phi(r^2-4n) q^n zeta^r.
+        When, in this code part, we speak of Jacobi form we only mean this part.
+        
+        We need to compute Ifg = \sum_{r=0,1; n} c(r^2-4n) q^n zeta^r up to
+        4n-r^2 <= Dtop, i.e. n < precision
+        """
+
+        ## Create the Jacobi forms A=a*etapow and B=b*etapow in stages.
+        ## Recall a = sum_{s != r mod 2} s^2*(-1)^r*q^((s^2+r^2-1)/4)*zeta^r
+        ##        b = sum_{s != r mod 2}     (-1)^r*q^((s^2+r^2-1)/4)*zeta^r
+        ## r, s run over ZZ but with opposite parities.
+        ## For r=0, we need s odd, (s^2-1)/4 < precision, with s=2t+1 hence t^2+t < precision.
+        ## For r=1, we need s even, s^2/4 < precision, with s=2t hence t^2 < precision.
+    
+        ## we use a slightly overestimated ab_prec 
+        
+        ab_prec = isqrt(qexp_prec + 1)
+        a1dict = dict(); a0dict = dict()
+        b1dict = dict(); b0dict = dict()
+    
+        for t in xrange(1, ab_prec + 1) :
+            tmp = t**2
+            a1dict[tmp] = -8*tmp
+            b1dict[tmp] = -2
+        
+            tmp += t
+            a0dict[tmp] = 8*tmp + 2
+            b0dict[tmp] = 2
+        b1dict[0] = -1
+        a0dict[0] = 2; b0dict[0] = 2 
+        
+        a1 = PS(a1dict); b1 = PS(b1dict)
+        a0 = PS(a0dict); b0 = PS(b0dict)
+
+        ## Finally: I(f,g) is given by the formula below:
+        ## We multiply by etapow explecitely and save two multiplications
+        # Ifg0 = k/2*f*A0 - fderiv*B0 + g*B0 + O(q^precision)
+        # Ifg1 = k/2*f*A1 - fderiv*B1 + g*B1 + O(q^precision)
+        Ifg0 = (self._eta_power() * (f*a0 + gfderiv*b0)).list()
+        Ifg1 = (self._eta_power() * (f*a1 + gfderiv*b1)).list()
+
+        if len(Ifg0) < qexp_prec :
+            Ifg0 += [0]*(qexp_prec - len(Ifg0))
+        if len(Ifg1) < qexp_prec :
+            Ifg1 += [0]*(qexp_prec - len(Ifg1))
+        
+        ## For applying the Maass' lifting to genus 2 modular forms.
+        ## we put the coefficients of Ifg into a dictionary Chi
+        ## so that we can access the coefficient corresponding to 
+        ## discriminant D by going Chi[D].
+        
+        Cphi = dict([(0,0)])
+        for i in xrange(qexp_prec) :
+            Cphi[-4*i] = Ifg0[i]
+            Cphi[1-4*i] = Ifg1[i]
+
+        del Ifg0[:], Ifg1[:]
+
+        """
+        Create the Maas lift F := VI(f,g) as in [Sko].
+        """
+        
+        ## The constant term is given by -Cphi[0]*B_{2k}/(4*k)
+        ## (note in [Sko] this coeff has typos).
+        ## For nonconstant terms,
+        ## The Siegel coefficient of q^n * zeta^r * qdash^m is given 
+        ## by the formula  \sum_{ a | gcd(n,r,m) } Cphi[D/a^2] where 
+        ## D = r^2-4*n*m is the discriminant.  
+        ## Hence in either case the coefficient 
+        ## is fully deterimined by the pair (D,gcd(n,r,m)).
+        ## Put (D,t) -> \sum_{ a | t } Cphi[D/a^2]
+        ## in a dictionary (hash table) maassc.
+
+        maass_coeffs = dict()
+        divisor_dict = self._divisor_dict()
+
+        ## First calculate maass coefficients corresponding to strictly positive definite matrices:        
+        for disc in self._negative_fundamental_discriminants() :
+            for s in xrange(1, isqrt((-self.__precision.discriminant()) // disc) + 1) :
+                ## add (disc*s^2,t) as a hash key, for each t that divides s
+                for t in divisor_dict[s] :
+                    maass_coeffs[(disc * s**2,t)] = \
+                       sum( a**(k-1) * Cphi[disc * s**2 / a**2] 
+                            for a in divisor_dict[t] )
+
+        ## Compute the coefficients of the Siegel form $F$:
+        siegel_coeffs = dict()
+        for (n,r,m), g in self.__precision.iter_positive_forms_with_content() :
+            siegel_coeffs[(n,r,m)] = maass_coeffs[(r**2 - 4*m*n, g)]
+
+        ## Secondly, deal with the singular part.
+        ## Include the coeff corresponding to (0,0,0):
+        ## maass_coeffs = {(0,0): -bernoulli(k)/(2*k)*Cphi[0]}
+        siegel_coeffs[(0,0,0)] = -bernoulli(k)/(2*k)*Cphi[0]
+        if is_integral :
+            siegel_coeffs[(0,0,0)] = Integer(siegel_coeffs[(0,0,0)])
+        
+        ## Calculate the other discriminant-zero maass coefficients.
+        ## Since sigma is quite cheap it is faster to estimate the bound and
+        ## save the time for repeated calculation
+        for i in xrange(1, self.__precision._indefinite_content_bound()) :
+            ## maass_coeffs[(0,i)] = sigma(i, k-1) * Cphi[0]
+            siegel_coeffs[(0,0,i)] = sigma(i, k-1) * Cphi[0]
+
+        return siegel_coeffs
+
+    def maass_eisensteinseries(self, k) :
+        if not isinstance(k, (int, Integer)) :
+            raise TypeError, "k must be an integer"
+        if k % 2 != 0 or k < 4 :
+            raise ValueError, "k must be even and greater than 4"
+        
+        return self.maass_form(ModularForms(1,k).eisenstein_subspace().gen(0), 0)
+  
+    ## TODO: Rework these functions
+    def from_gram_matrix( self, gram, name = None) :
+        raise NotImplementedError, "matrix argument not yet implemented"
+
+    def _SiegelModularForm_borcherds_lift( self, f, prec = 100, name = None):
+    
+        raise NotImplementedError, "matrix argument not yet implemented"
+
+    def _SiegelModularForm_yoshida_lift( self, f, g, prec = 100, name = None):
+    
+        raise NotImplementedError, "matrix argument not yet implemented"
+
+    def _SiegelModularForm_from_weil_representation( self, gram, prec = 100, name = None):
+    
+        raise NotImplementedError, "matrix argument not yet implemented"
+
+    def _SiegelModularForm_singular_weight( self, gram, prec = 100, name = None):
+    
+        raise NotImplementedError, "matrix argument not yet implemented"
+
+    def _repr_(self) :
+        return "Factory class for Siegel modular forms of genus 2 with precision %s" % \
+               repr(self.__precision.discriminant())
+    
+    def _latex_(self) :
+        return "Factory class for Siegel modular forms of genus $2$ with precision %s" % \
+               latex(self.__precision.discriminant())

--- a/psage/modform/paramodularforms/siegelmodularformg2_fourierexpansion.py
+++ b/psage/modform/paramodularforms/siegelmodularformg2_fourierexpansion.py
@@ -1,0 +1,432 @@
+r"""
+Classes describing the fourier expansion of Siegel modular forms genus 2.
+
+AUTHORS:
+
+- Martin Raum (2009 - 07 - 28) Initial version
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2009 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids import TrivialCharacterMonoid, \
+                                           TrivialRepresentation
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring import EquivariantMonoidPowerSeriesRing
+from operator import xor
+from sage.functions.other import floor
+from sage.functions.other import sqrt
+from sage.misc.functional import isqrt
+from sage.misc.latex import latex
+from sage.rings.arith import gcd
+from sage.rings.infinity import infinity
+from sage.rings.integer_ring import ZZ
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.rational_field import QQ
+from sage.structure.sage_object import SageObject
+from psage.modform.paramodularforms.siegelmodularformg2_fourierexpansion_cython import \
+                     mult_coeff_int_without_character, \
+                     mult_coeff_generic_without_character, \
+                     reduce_GL, xreduce_GL
+from sage.rings.integer import Integer
+
+#===============================================================================
+# SiegelModularFormG2Filter_discriminant
+#===============================================================================
+
+class SiegelModularFormG2Filter_discriminant ( SageObject ) :
+    def __init__(self, disc, reduced = True) :
+        if isinstance(disc, SiegelModularFormG2Filter_discriminant) :
+            disc = disc.index()
+
+        if disc is infinity :
+            self.__disc = disc
+        else :
+            Dmod = disc % 4
+            if Dmod >= 2 :
+                self.__disc = disc - Dmod + 1
+            else :
+                self.__disc = disc
+
+        self.__reduced = reduced
+
+    def filter_all(self) :
+        return SiegelModularFormG2Filter_discriminant(infinity, self.__reduced)
+    
+    def zero_filter(self) :
+        return SiegelModularFormG2Filter_discriminant(0, self.__reduced) 
+
+    def is_infinite(self) :
+        return self.__disc is infinity
+
+    def is_all(self) :
+        return self.is_infinite()
+
+    def index(self) :
+        return self.__disc
+
+    def discriminant(self) :
+        return self.index()
+    
+    def is_reduced(self) :
+        return self.__reduced
+    
+    def __contains__(self, f) :
+        if self.__disc is infinity :
+            return True
+        
+        (a, b, c) = f
+        disc = 4*a*c - b**2
+        if disc == 0 :
+            return gcd([a, b, c]) < self._indefinite_content_bound()
+        else :
+            return disc < self.__disc
+    
+    def _indefinite_content_bound(self) :
+        r"""
+        Return the maximal trace for semi definite forms, which are considered
+        to be below this precision.
+        """
+        return max(1, 2 * self.index() // 3) if self.index() != 0 else 0
+    
+    def __iter__(self) :
+        if self.__disc is infinity :
+            raise ValueError, "infinity is not a true filter index"
+        
+        if self.__reduced :
+            for c in xrange(0, self._indefinite_content_bound()) :
+                yield (0,0,c)
+                
+            for a in xrange(1,isqrt(self.__disc // 3) + 1) :
+                for b in xrange(a+1) :
+                    for c in xrange(a, (b**2 + (self.__disc - 1))//(4*a) + 1) :
+                        yield (a,b,c)
+        else :
+            ##FIXME: These are not all matrices
+            for a in xrange(0, self._indefinite_content_bound()) :
+                yield (a,0,0)
+            for c in xrange(1, self._indefinite_content_bound()) :
+                yield (0,0,c)
+            
+            maxtrace = floor(5*self.__disc / 15 + sqrt(self.__disc)/2)
+            for a in xrange(1, maxtrace + 1) :
+                for c in xrange(1, maxtrace - a + 1) :
+                    Bu = isqrt(4*a*c - 1)
+
+                    di = 4*a*c - self.__disc
+                    if di >= 0 :
+                        Bl = isqrt(di) + 1 
+                    else :
+                        Bl = 0
+                    
+                    for b in xrange(-Bu, -Bl + 1) :
+                        yield (a,b,c)
+                    for b in xrange(Bl, Bu + 1) :
+                        yield (a,b,c)
+        #! if self.__reduced
+        
+        raise StopIteration
+
+    def iter_positive_forms_with_content(self) :
+        if self.__disc is infinity :
+            raise ValueError, "infinity is not a true filter index"
+        
+        
+        if self.__reduced :        
+            for a in xrange(1,isqrt(self.__disc // 3) + 1) :
+                for b in xrange(a+1) :
+                    g = gcd(a, b)
+                    for c in xrange(a, (b**2 + (self.__disc - 1))//(4*a) + 1) :
+                        yield (a,b,c), gcd(g,c)
+        else :
+            maxtrace = floor(5*self.__disc / 15 + sqrt(self.__disc)/2)
+            for a in xrange(1, maxtrace + 1) :
+                for c in xrange(1, maxtrace - a + 1) :
+                    g = gcd(a,c)
+                    
+                    Bu = isqrt(4*a*c - 1)
+
+                    di = 4*a*c - self.__disc
+                    if di >= 0 :
+                        Bl = isqrt(di) + 1 
+                    else :
+                        Bl = 0
+                    
+                    for b in xrange(-Bu, -Bl + 1) :
+                        yield (a,b,c), gcd(g,b)
+                    for b in xrange(Bl, Bu + 1) :
+                        yield (a,b,c), gcd(g,b)
+        #! if self.__reduced
+
+        raise StopIteration
+    
+    def iter_indefinite_forms(self) :
+        if self.__disc is infinity :
+            raise ValueError, "infinity is not a true filter index"
+        
+        
+        if self.__reduced :
+            for c in xrange(self._indefinite_content_bound()) :
+                yield (0, 0, c)
+        else :
+            raise NotImplementedError
+        
+        raise StopIteration
+    
+    def _hecke_operator(self, n) :
+        return SiegelModularFormG2Filter_discriminant(self.__disc // n**2, self.__reduced) 
+    
+    def __cmp__(self, other) :
+        c = cmp(type(self), type(other))
+        if c == 0 :
+            c = cmp(self.__reduced, other.__reduced)
+        if c == 0 :
+            c = cmp(self.__disc, other.__disc)
+            
+        return c
+
+    def __hash__(self) :
+        return reduce(xor, map(hash, [type(self), self.__reduced, self.__disc]))
+                                         
+    def _repr_(self) :
+        return "Discriminant filter (%s)" % self.__disc
+    
+    def _latex_(self) :
+        return "Discriminant filter (%s)" % latex(self.__disc)
+    
+#===============================================================================
+# SiegelModularFormG2Indices_discriminant_xreduce
+#===============================================================================
+
+class SiegelModularFormG2Indices_discriminant_xreduce( SageObject ) :
+    r"""
+    All positive definite quadratic forms filtered by their discriminant.
+    """
+    def __init__(self, reduced = True) :
+        self.__reduced = reduced
+
+    def ngens(self) :
+        return 4 if not self.__reduced else 3
+    
+    def gen(self, i = 0) :
+        if i == 0 :
+            return (1, 0, 0)
+        elif i == 1 :
+            return (0, 0, 1)
+        elif i == 2 :
+            return (1, 1, 1)
+        elif not self.__reduced and i == 3 :
+            return (1, -1, 1)
+        
+        raise ValueError, "Generator not defined"
+    
+    def gens(self) :    
+        return [self.gen(i) for i in xrange(self.ngens())]
+
+    def is_commutative(self) :
+        return True
+    
+    def monoid(self) :
+        return SiegelModularFormG2Indices_discriminant_xreduce(False) 
+
+    def group(self) :
+        return "GL(2,ZZ)"
+        
+    def is_monoid_action(self) :
+        r"""
+        True if the representation respects the monoid structure.
+        """
+        return True
+    
+    def filter(self, disc) :
+        return SiegelModularFormG2Filter_discriminant(disc, self.__reduced)
+        
+    def filter_all(self) :
+        return SiegelModularFormG2Filter_discriminant(infinity, self.__reduced)
+    
+    def minimal_composition_filter(self, ls, rs) :
+        if len(ls) == 0 or len(rs) == 0 :
+            return SiegelModularFormG2Filter_discriminant(0, self.__reduced)
+        
+        if len(ls) == 1 and ls[0] == (0,0,0) :
+            return SiegelModularFormG2Filter_discriminant(min(4*a*c - b**2 for (a,b,c) in rs) + 1,
+                                      self.__reduced)
+        if len(rs) == 1 and rs[0] == (0,0,0) :
+            return SiegelModularFormG2Filter_discriminant(min(4*a*c - b**2 for (a,b,c) in ls) + 1,
+                                      self.__reduced)
+        
+        raise ArithmeticError, "Discriminant filter does not " + \
+                               "admit minimal composition filters"
+        
+    def _reduction_function(self) :
+        return xreduce_GL
+    
+    def reduce(self, s) :
+        return xreduce_GL(s)
+  
+    def decompositions(self, s) :
+        (a, b, c) = s
+        
+        for a1 in xrange(a + 1) :
+            a2 = a - a1
+            for c1 in xrange(c + 1) :
+                c2 = c - c1
+                
+                B1 = isqrt(4*a1*c1)
+                B2 = isqrt(4*a2*c2)
+                for b1 in xrange(max(-B1, b - B2), min(B1 + 1, b + B2 + 1)) :
+                    yield ((a1, b1, c1), (a2,b - b1, c2))
+        
+        raise StopIteration
+    
+    def zero_element(self) :
+        return (0,0,0)
+
+    def __contains__(self, x) :
+        return isinstance(x, tuple) and len(x) == 3 and \
+               all(isinstance(e, (int,Integer)) for e in x)
+        
+    def __cmp__(self, other) :
+        c = cmp(type(self), type(other))
+        if c == 0 :
+            c = cmp(self.__reduced, other.__reduced)
+            
+        return c
+    
+    def __hash__(self) :
+        return hash(self.__reduced)
+    
+    def _repr_(self) :
+        if self.__reduced :
+            return "Reduced quadratic forms over ZZ"
+        else :
+            return "Quadratic forms over ZZ"
+            
+    def _latex_(self) :
+        return self._repr_() 
+
+#===============================================================================
+# SiegelModularFormG2VVRepresentation
+#===============================================================================
+
+class SiegelModularFormG2VVRepresentation ( SageObject ) :
+    def __init__(self, K) :
+        self.__K = K
+        self.__R = PolynomialRing(K, ['x', 'y'])
+        self.__x = self.__R.gen(0)
+        self.__y = self.__R.gen(1)
+    
+    def from_module(self, R) :
+        assert R == PolynomialRing(R.base_ring(), ['x', 'y'])
+        
+        return SiegelModularFormG2VVRepresentation(R.base_ring())
+        
+    def base_ring(self) :
+        return self.__K
+    
+    def codomain(self) :
+        return self.__R
+    
+    def base_extend(self, L) :
+        if L.has_coerce_map_from(self.__K) :
+            return SiegelModularFormG2VVRepresentation( L )
+        
+        raise ValueError, "Base extension of representation is not defined"
+        
+    def extends(self, other) :
+        if isinstance(other, TrivialRepresentation) :
+            return self.__K.has_coerce_map_from(other.codomain())
+        elif type(self) != type(other) :
+            return False
+        
+        return self.__K.has_coerce_map_from(other.__K)
+        
+    def group(self) :
+        return "GL(2,ZZ)"
+    
+    def _apply_function(self) :
+        return self.apply
+    
+    def apply(self, g, a) :
+        return a(g[0]*self.__x + g[1]*self.__y, g[2]*self.__x + g[3]*self.__y)
+    
+    def __cmp__(self, other) :
+        c = cmp(type(self), type(other))
+        
+        if c == 0 :
+            c = cmp(self.__K, other.__K)
+            
+        return c
+    
+    def __hash__(self) :
+        return hash(self.__K)
+
+    def _repr_(self) :
+        return "Siegel modular form degree 2 vector valued representation on %s" % (self.__K)
+    
+    def _latex_(self) :
+        return "Siegel modular form degree 2 vector valued representation on %s" % (latex(self.__K))
+
+#===============================================================================
+# SiegelModularFormG2FourierExpansionRing
+#===============================================================================
+
+def SiegelModularFormG2FourierExpansionRing(K, with_character = False) :
+    
+    if with_character :
+        raise NotImplementedError
+    
+        #R = EquivariantMonoidPowerSeriesRing(
+        #     SiegelModularFormG2Indices_discriminant_xreduce(),
+        #     GL2CharacterMonoid(K),
+        #     TrivialRepresentation("GL(2,ZZ)", K) )
+        # Characters in GL2CharacterMonoid should accept (det, sgn)
+        #R._set_reduction_function(sreduce_GL)
+
+        #if K is ZZ :
+        #    R._set_multiply_function(mult_coeff_int_character)
+        #else :
+        #    R._set_multiply_function(mult_coeff_generic_character)
+    else : 
+        R = EquivariantMonoidPowerSeriesRing(
+             SiegelModularFormG2Indices_discriminant_xreduce(),
+             TrivialCharacterMonoid("GL(2,ZZ)", ZZ),
+             TrivialRepresentation("GL(2,ZZ)", K) )
+
+        R._set_reduction_function(reduce_GL)
+    
+        if K is ZZ :
+            R._set_multiply_function(mult_coeff_int_without_character)
+        else :
+            R._set_multiply_function(mult_coeff_generic_without_character)
+        
+    return R
+
+#===============================================================================
+# SiegelModularFormG2VVFourierExpansionRing
+#===============================================================================
+
+## TODO: This is far from optimal. For specific weights we can use
+##       free modules.
+def SiegelModularFormG2VVFourierExpansionRing(K) :
+    R = EquivariantMonoidPowerSeriesRing(
+         SiegelModularFormG2Indices_discriminant_xreduce(),
+         TrivialCharacterMonoid("GL(2,ZZ)", ZZ),
+         SiegelModularFormG2VVRepresentation(K) )
+        
+    return R

--- a/psage/modform/paramodularforms/siegelmodularformg2_fourierexpansion_cython.pxd
+++ b/psage/modform/paramodularforms/siegelmodularformg2_fourierexpansion_cython.pxd
@@ -1,0 +1,8 @@
+include 'sage/ext/stdsage.pxi'
+include 'sage/ext/cdefs.pxi'
+
+from sage.rings.ring cimport Ring
+
+
+cpdef mult_coeff_int_without_character(result_key, coeffs_dict1, coeffs_dict2, ch1, ch2, result)
+cpdef mult_coeff_generic_without_character(result_key, coeffs_dict1, coeffs_dict2, ch1, ch2, result)

--- a/psage/modform/paramodularforms/siegelmodularformg2_fourierexpansion_cython.pyx
+++ b/psage/modform/paramodularforms/siegelmodularformg2_fourierexpansion_cython.pyx
@@ -1,0 +1,490 @@
+r"""
+Functions for reduction of fourier indices and for multiplication of
+Siegel modular forms.
+
+AUTHORS:
+
+- Craig Citro, Nathan Ryan Initian version
+- Martin Raum (2009 - 04) Refined multiplication by Martin Raum
+- Martin Raum (2009 - 07 - 28) Port to new framework
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2009 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+## TODO : Clean this file up.
+
+include "interrupt.pxi"
+include "stdsage.pxi"
+include "cdefs.pxi"
+
+include 'sage/ext/gmp.pxi'
+
+from sage.rings.integer cimport Integer
+from sage.rings.ring cimport Ring
+
+cdef struct int_triple:
+    int a
+    int b
+    int c
+
+cdef struct int_quinruple:
+    int a
+    int b
+    int c
+    int d # determinant of reducing g \in GL2
+    int s # sign of reducing g \in GL2
+    
+cdef struct int_septuple:
+    int a
+    int b
+    int c
+    int O # upper left entry of reducing g \in GL2
+    int o # upper right entry of reducing g \in GL2
+    int U # lower left entry of reducing g \in GL2
+    int u # lower right entry of reducing g \in GL2
+
+
+#####################################################################
+#####################################################################
+#####################################################################
+
+#===============================================================================
+# reduce_GL
+#===============================================================================
+
+def reduce_GL(tripel) :
+    r"""
+    Return the `GL_2(\ZZ)`-reduced form equivalent to (positive semidefinite)
+    quadratic form `a x^2 + b x y + c y^2`.
+    """
+    cdef int a, b, c
+    cdef int_triple res
+
+    # We want to check that (a,b,c) is semipositive definite
+    # since otherwise we might end up in an infinite loop.
+    # TODO: the discriminant can become to big
+    if b*b-4*a*c > 0 or a < 0 or c < 0:
+        raise NotImplementedError, "only implemented for nonpositive discriminant"
+
+    (a, b, c) = tripel            
+    res = _reduce_GL(a, b, c)
+
+    return ((res.a, res.b, res.c), 0)
+
+#===============================================================================
+# _reduce_GL
+#===============================================================================
+
+cdef int_triple _reduce_GL(int a, int b, int c) :
+    r"""
+    Return the `GL_2(\ZZ)`-reduced form equivalent to (positive semidefinite)
+    quadratic form `a x^2 + b x y + c y^2`.
+    (Following Algorithm 5.4.2 found in Cohen's Computational Algebraic Number Theory.)
+    """
+    cdef int_triple res
+    cdef int twoa, q, r
+    cdef int tmp
+
+    if b < 0:
+        b = -b
+        
+    while not (b<=a and a<=c):  ## while not GL-reduced
+        twoa = 2 * a
+        #if b not in range(-a+1,a+1):
+        if b > a:
+            ## apply Euclidean step (translation)
+            q = b / twoa #(2*a) 
+            r = b % twoa  #(2*a)
+            if r > a:
+                ## want (quotient and) remainder such that -a<r<=a
+                r = r - twoa  # 2*a;
+                q = q + 1
+            c = c-b*q+a*q*q
+            b = r
+            
+        ## apply symmetric step (reflection) if necessary
+        if a > c:
+            #(a,c) = (c,a)
+            tmp = c
+            c = a
+            a = tmp
+
+        #b=abs(b)
+        if b < 0:
+            b = -b
+        ## iterate
+    ## We're finished! Return the GL2(ZZ)-reduced form (a,b,c):
+
+    res.a = a
+    res.b = b
+    res.c = c
+            
+    return res
+
+##TODO: This is a mess. In former implementations the sign was the determinant
+##      of the reducing matrix. This has to be replaced by d and the sign is the
+##      GL2(F_2) \cong S_3 character
+
+#===============================================================================
+# #==============================================================================
+# # sreduce_GL
+# #==============================================================================
+# 
+# def sreduce_GL(a, b, c):
+#    """
+#    Return the GL2(ZZ)-reduced form f and a determinant d and a sign s such
+#    that d is the determinant of the matrices M in GL2(ZZ) such that
+#    ax^2+bxy+cy^2 = f((x,y)*M).
+#    """
+#    cdef int_quadruple res
+# 
+#    # We want to check that (a,b,c) is semipositive definite
+#    # since otherwise we might end up in an infinite loop.
+#    if b*b-4*a*c > 0 or a < 0 or c < 0:
+#        raise NotImplementedError, "only implemented for nonpositive discriminant"
+#            
+#    res = _sreduce_GL(a, b, c)
+#    return ((res.a, res.b, res.c), (res.d, res.s))
+# 
+# #===============================================================================
+# # int_quintuple _sreduce_GL
+# #===============================================================================
+# 
+# cdef int_quintuple _sreduce_GL(int a, int b, int c):
+#    """
+#    Return the GL2(ZZ)-reduced form equivalent to (positive semidefinite)
+#    quadratic form ax^2+bxy+cy^2.
+#    (Following algorithm 5.4.2 found in Cohen's Computational Algebraic Number Theory.)
+# 
+#    TODO
+#         _xreduce_GL is a factor 20 slower than xreduce_GL.
+#         How can we improve this factor ?
+# 
+#    """
+#    cdef int_quadruple res
+#    cdef int twoa, q, r
+#    cdef int tmp
+#    cdef int s
+#    
+#    # If [A,B,C] is the form to be reduced, then after each reduction
+#    # step we have s = det(M), where M is the GL2(ZZ)-matrix
+#    # such that [A,B,C] =[a,b,c]( (x,y)*M)
+#    s = 1
+#    if b < 0:
+#        b = -b
+#        s = -1
+#        
+#    while not (b<=a and a<=c):  ## while not GL-reduced
+#        twoa = 2 * a
+#        #if b not in range(-a+1,a+1):
+#        if b > a:
+#            ## apply Euclidean step (translation)
+#            q = b / twoa #(2*a) 
+#            r = b % twoa  #(2*a)
+#            if r > a:
+#                ## want (quotient and) remainder such that -a<r<=a
+#                r = r - twoa  # 2*a;
+#                q = q + 1
+#            c = c-b*q+a*q*q
+#            b = r
+#            
+#        ## apply symmetric step (reflection) if necessary
+#        if a > c:
+#            #(a,c) = (c,a)
+#            tmp = c; c = a; a = tmp
+#            s *= -1
+#            
+#        #b=abs(b)
+#        if b < 0:
+#            b = -b
+#            s *= -1
+# 
+#        ## iterate
+#    ## We're finished! Return the GL2(ZZ)-reduced form (a,b,c) and the O,o,U,u-matrix:
+# 
+#    res.a = a
+#    res.b = b
+#    res.c = c
+#    res.s = s
+#            
+#    return res
+#===============================================================================
+
+#===============================================================================
+# xreduce_GL
+#===============================================================================
+
+def xreduce_GL(tripel) :
+    r"""
+    Return the `GL_2(\ZZ)`-reduced form equivalent to (positive semidefinite)
+    quadratic form `a x^2 + b x y + c y^2`.
+    """
+    cdef int a, b, c
+    cdef int_septuple res
+
+    # We want to check that (a,b,c) is semipositive definite
+    # since otherwise we might end up in an infinite loop.
+#    if b*b-4*a*c > 0 or a < 0 or c < 0:
+#        raise NotImplementedError, "only implemented for nonpositive discriminant"
+
+    (a, b, c) = tripel            
+    res = _xreduce_GL(a, b, c)
+    return ((res.a, res.b, res.c), (res.O, res.o, res.U, res.u))
+
+#===============================================================================
+# _xreduce_GL
+#===============================================================================
+
+cdef int_septuple _xreduce_GL(int a, int b, int c) :
+    r"""
+    Return the `GL_2(\ZZ)`-reduced form `f` and a matrix `M` such that
+    `a x^2 + b x y + c y^2 = f( (x,y)*M )`.
+
+    TODO:
+    
+         ``_xreduce_GL`` is a factor 20 slower than ``xreduce_GL``.
+         How can we improve this factor ?
+
+    """
+    cdef int_septuple res
+    cdef int twoa, q, r
+    cdef int tmp
+    cdef int O,o,U,u
+    
+    # If [A,B,C] is the form to be reduced, then after each reduction
+    # step we have [A,B,C] =[a,b,c]( (x,y)*matrix(2,2,[O,o, U,u]) )
+    O = u = 1
+    o = U = 0
+
+    if b < 0:
+        b = -b
+        O = -1
+        
+    while not (b<=a and a<=c):  ## while not GL-reduced
+        twoa = 2 * a
+        #if b not in range(-a+1,a+1):
+        if b > a:
+            ## apply Euclidean step (translation)
+            q = b / twoa #(2*a) 
+            r = b % twoa  #(2*a)
+            if r > a:
+                ## want (quotient and) remainder such that -a<r<=a
+                r = r - twoa  # 2*a;
+                q = q + 1
+            c = c-b*q+a*q*q
+            b = r
+            O += q*o
+            U += q*u
+            
+        ## apply symmetric step (reflection) if necessary
+        if a > c:
+            #(a,c) = (c,a)
+            tmp = c; c = a; a = tmp
+            tmp = O; O = o; o = tmp
+            tmp = U; U = u; u = tmp
+            
+        #b=abs(b)
+        if b < 0:
+            b = -b
+            O = -O
+            U = -U
+
+        ## iterate
+    ## We're finished! Return the GL2(ZZ)-reduced form (a,b,c) and the O,o,U,u-matrix:
+
+    res.a = a
+    res.b = b
+    res.c = c
+    res.O = O
+    res.o = o
+    res.U = U
+    res.u = u
+            
+    return res
+
+#####################################################################
+#####################################################################
+#####################################################################
+
+#===============================================================================
+# mult_coeff_int_without_character
+#===============================================================================
+
+cpdef mult_coeff_int_without_character(result_key,
+       coeffs_dict1, coeffs_dict2, ch1, ch2, result) :
+    r"""
+    Returns the value at `(a, b, c)` of the coefficient dictionary of the product
+    of the two forms with dictionaries ``coeffs_dict1`` and ``coeffs_dict2``.
+    It is assumed that `(a, b, c)` is a key in ``coeffs_dict1`` and ``coeffs_dict2``.
+    """
+    cdef int a, b, c
+    cdef int a1, a2
+    cdef int b1, b2
+    cdef int c1, c2
+    cdef int B1, B2
+    
+    cdef mpz_t tmp, mpz_zero
+    cdef mpz_t left, right
+    cdef mpz_t acc
+
+    mpz_init(tmp)
+    mpz_init(mpz_zero)
+    mpz_init(left)
+    mpz_init(right)
+    mpz_init(acc)
+
+    (a, b, c) = result_key
+
+    _sig_on
+    for a1 from 0 <= a1 < a+1 :
+        a2 = a - a1
+        for c1 from 0 <= c1 < c+1 :
+            c2 = c - c1
+            mpz_set_si(tmp, 4*a1*c1)
+            mpz_sqrt(tmp, tmp)
+            B1 = mpz_get_si(tmp)
+
+            mpz_set_si(tmp, 4*a2*c2)
+            mpz_sqrt(tmp, tmp)
+            B2 = mpz_get_si(tmp)
+
+            for b1 from max(-B1, b - B2) <= b1 < min(B1 + 1, b + B2 + 1) :
+                ## Guarantes that both (a1,b1,c1) and (a2,b2,c2) are
+                ## positive semidefinite                
+                b2 = b - b1
+                
+                get_coeff_int(left, a1, b1, c1, coeffs_dict1)
+                if mpz_cmp(left, mpz_zero) == 0 : continue
+                
+                get_coeff_int(right, a2, b2, c2, coeffs_dict2)
+                if mpz_cmp(right, mpz_zero) == 0 : continue
+                
+                mpz_mul(tmp, left, right)
+                mpz_add(acc, acc, tmp)
+    _sig_off
+    
+    mpz_set((<Integer>result).value, acc)
+    
+    mpz_clear(tmp)
+    mpz_clear(mpz_zero)
+    mpz_clear(left)
+    mpz_clear(right)
+    mpz_clear(acc)
+    
+    return result
+
+#===============================================================================
+# mult_coeff_generic_without_character
+#===============================================================================
+
+cpdef mult_coeff_generic_without_character(result_key,
+       coeffs_dict1, coeffs_dict2, ch1, ch2, result) :
+    r"""
+    Returns the value at `(a, b, c)`of the coefficient dictionary of the product
+    of the two forms with dictionaries ``coeffs_dict1`` and ``coeffs_dict2``.
+    It is assumed that `(a, b, c)` is a key in ``coeffs_dict1`` and ``coeffs_dict2``.
+    """
+    cdef int a, b, c
+    cdef int a1, a2
+    cdef int b1, b2
+    cdef int c1, c2
+    cdef int B1, B2
+
+    cdef mpz_t tmp
+
+    mpz_init(tmp)
+
+    (a, b, c) = result_key
+
+    _sig_on
+    for a1 from 0 <= a1 < a+1:
+        a2 = a - a1
+        for c1 from 0 <= c1 < c+1:
+            c2 = c - c1
+            mpz_set_si(tmp, 4*a1*c1)
+            mpz_sqrt(tmp, tmp)
+            B1 = mpz_get_si(tmp)
+
+            mpz_set_si(tmp, 4*a2*c2)
+            mpz_sqrt(tmp, tmp)
+            B2 = mpz_get_si(tmp)
+
+            for b1 from max(-B1, b - B2) <= b1 < min(B1 + 1, b + B2 + 1) :
+                ## Guarantes that both (a1,b1,c1) and (a2,b2,c2) are
+                ## positive semidefinite                
+                b2 = b - b1
+
+                left = get_coeff_generic(a1, b1, c1, coeffs_dict1)
+                if left is None : continue
+                
+                right = get_coeff_generic(a2, b2, c2, coeffs_dict2)
+                if right is None : continue
+                
+                result += left*right
+    _sig_off
+
+    mpz_clear(tmp)
+
+    return result
+
+#####################################################################
+
+#===============================================================================
+# get_coeff_int
+#===============================================================================
+
+cdef inline void get_coeff_int(mpz_t dest, int a, int b, int c, coeffs_dict):
+    r"""
+    Return the value of ``coeffs_dict`` at the triple obtained from
+    reducing `(a, b, c)`.
+    It is assumed that the latter is a valid key
+    and that `(a, b, c)` is positive semi-definite. 
+    """
+    cdef int_triple tmp_triple
+
+    mpz_set_si(dest, 0)
+
+    tmp_triple = _reduce_GL(a, b, c)
+    triple = (tmp_triple.a, tmp_triple.b, tmp_triple.c)
+    try :
+        mpz_set(dest, (<Integer>(coeffs_dict[triple])).value)
+    except KeyError :
+        pass
+
+#===============================================================================
+# get_coeff_generic
+#===============================================================================
+
+cdef get_coeff_generic(int a, int b, int c, coeffs_dict):
+    r"""
+    Return the value of ``coeffs_dict`` at the triple obtained from
+    reducing `(a, b, c)`.
+    It is assumed that the latter is a valid key
+    and that `(a, b, c)` is positive semi-definite. 
+    """
+    cdef int_triple tmp_triple
+
+    tmp_triple = _reduce_GL(a, b, c)
+    triple = (tmp_triple.a, tmp_triple.b, tmp_triple.c)
+    
+    try :
+        return coeffs_dict[triple]
+    except KeyError :
+        return None

--- a/psage/modform/paramodularforms/siegelmodularformg2_heckeaction.py
+++ b/psage/modform/paramodularforms/siegelmodularformg2_heckeaction.py
@@ -1,0 +1,150 @@
+r"""
+The Hecke action on Siegel modular forms of genus 2.
+
+AUTHORS:
+
+- Martin Raum (2009 - 08 - 28) Initial version based on code by Nathan Ryan.
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2009 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from sage.misc.cachefunc import cached_method
+from sage.misc.latex import latex
+from sage.modular.modsym.p1list import P1List
+from sage.rings.integer import Integer
+from sage.structure.sage_object import SageObject
+from psage.modform.paramodularforms import siegelmodularformg2_misc_cython
+
+_siegelmodularformg2_heckeoperator_cache = dict()
+
+#===============================================================================
+# SiegelModularFormG2FourierExpansionHeckeAction
+#===============================================================================
+
+def SiegelModularFormG2FourierExpansionHeckeAction( n ) :
+    global _siegelmodularformg2_heckeoperator_cache
+    
+    try :
+        return _siegelmodularformg2_heckeoperator_cache[n]
+    except KeyError :
+        A = SiegelModularFormG2FourierExpansionHeckeAction_class(n)
+        _siegelmodularformg2_heckeoperator_cache[n] = A
+        
+        return A
+
+#===============================================================================
+# SiegelModularFormG2FourierExpansionHeckeAction_class
+#===============================================================================
+
+class SiegelModularFormG2FourierExpansionHeckeAction_class (SageObject):
+    r"""
+    Implements a Hecke operator acting on Siegel modular.
+    """
+
+    def __init__(self, n):
+        self.__l = n
+
+        self.__l_divisors = siegelmodularformg2_misc_cython.divisor_dict(n + 1)
+
+    def eval(self, expansion, weight = None) :
+        if weight is None :
+            try :
+                weight = expansion.weight()
+            except AttributeError :
+                raise ValueError, "weight must be defined for the Hecke action"
+            
+        precision = expansion.precision()
+        if precision.is_infinite() :
+            precision = expansion._bounding_precision()
+        else :
+            precision = precision._hecke_operator(self.__l)
+        characters = expansion.non_zero_components()
+        
+        hecke_expansion = dict()
+        for ch in characters :
+            hecke_expansion[ch] = dict( (k, self.hecke_coeff(expansion, ch, k, weight)) for k in precision )
+        
+        result = expansion.parent()._element_constructor_(hecke_expansion)
+        result._set_precision(expansion.precision()._hecke_operator(self.__l))
+        
+        return result
+        
+    # TODO : reimplement in cython
+    def hecke_coeff(self, expansion, ch, (a,b,c), k) :
+        r"""
+        Computes the coefficient indexed by `(a, b, c)` of `T(\ell) (F)`.
+        """
+        character_eval = expansion.parent()._character_eval_function()
+        
+        ell = self.__l
+        coeff = 0
+        for t1 in self.__l_divisors[ell]:
+            for t2 in self.__l_divisors[t1]:
+                for V in self.get_representatives(t1/t2):
+                    aprime, bprime, cprime = self.change_variables(V,(a,b,c))
+                    if aprime % t1 == 0 and bprime % t2 == 0 and cprime % t2 == 0:
+                        try:
+                            coeff = coeff + character_eval(V, ch) * t1**(k-2)*t2**(k-1)*expansion[( ch, ((ell*aprime) //t1**2,
+                                                                                                         (ell*bprime) //t1//t2,
+                                                                                                         (ell*cprime) //t2**2) )]
+                        except KeyError, msg:
+                            raise ValueError, '%s' %(expansion,msg)
+        return coeff
+
+    @cached_method
+    def get_representatives( self, t) :
+        r"""
+        A helper function used in hecke_coeff that computes the right
+        coset representatives of $\Gamma^0(t)\SL(2,Z)$ where
+        $\Gamma^0(t)$ is the subgroup of $SL(2,Z)$ where the upper right hand
+        corner is divisible by $t$.
+
+        NOTE:
+        
+            We use the bijection $\Gamma^0(t)\SL(2,Z) \rightarrow P^1(\Z/t\Z)$
+            given by $A \mapsto [1:0]A$.
+        """
+        if t == 1 : return [(1,0,0,1)]
+        
+        rep_list = []
+        
+        for x,y in P1List(t):
+            ## we calculate a pair c,d satisfying a minimality condition
+            ## to make later multiplications cheaper
+            (_, d, c) = Integer(x)._xgcd(Integer(y), minimal=True)
+            rep_list.append((x,y,-c,d))
+                
+        return rep_list
+
+    @staticmethod
+    def change_variables((a,b,c,d), (n,r,m)):
+        r"""
+        A helper function used in hecke_coeff that computes the
+        quadratic form [nprime,rprime,mprime] given by $Q((x,y) V)$
+        where $Q=[n,r,m]$ and $V$ is a 2 by 2 matrix given by `(a, b, c, d)`
+        """        
+        return ( n*a**2 + r*a*b + m*b**2, 2*(n*a*c + m*b*d) + r*(a*d + c*b), \
+                 n*c**2 + r*c*d + m*d**2 )
+
+    def _repr_(self) :
+        return '%s-th Hecke operator for Siegel modular forms' % self.__l
+
+    def _latex_(self) :
+        return latex(self.__n) + '-th Hecke operator for Siegel modular forms'

--- a/psage/modform/paramodularforms/siegelmodularformg2_maassproducts.py
+++ b/psage/modform/paramodularforms/siegelmodularformg2_maassproducts.py
@@ -1,0 +1,246 @@
+r"""
+Functions to create and use basis of graded modules which are products of
+Maass lifts.
+
+AUTHORS:
+
+- Martin Raum (2009 - 08 - 03) Initial version
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2009 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from sage.matrix.constructor import matrix
+from sage.misc.misc import prod
+from sage.rings.arith import random_prime
+from sage.rings.integer_ring import ZZ
+from sage.rings.padics.factory import Qp
+from sage.rings.rational_field import QQ
+from psage.modform.paramodularforms.siegelmodularformg2_fegenerators import SiegelModularFormG2MaassLift
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_lazyelement import EquivariantMonoidPowerSeries_LazyMultiplication
+from psage.modform.paramodularforms.siegelmodularformg2_submodule import SiegelModularFormG2Submodule_maassspace
+from sage.interfaces.magma import magma
+
+def spanning_maass_products(ring, weight, subspaces = None, lazy_rank_check = False) :
+    r"""This function is intended to quickly find good generators. This may be
+    calculated in low precision and then ported to higher.
+    
+    the maass spaces of all subspaces are expected to be ordered the same way as
+    ``ring.type()._maass_generator_preimages``.
+    """
+    ## Outline :
+    ##  - get the basis as polynomials form the ring
+    ##  - get the maass products, convert them to polynomials and try to 
+    ##  construct a basis
+    ##  - get the maass space associated to this weight and get its coordinates
+    ##  - return a basis containing of maass forms and the products
+
+    if subspaces is None :
+        subspaces = dict()
+        
+    assert ring.base_ring() is QQ or ring.base_ring() is ZZ, \
+           "%s doesn't have rational base field" % ring
+    
+    dim = ring.graded_submodule(weight).dimension()
+    precision = ring.fourier_expansion_precision()
+    maass_lift_func = ring.type()._maass_generators
+    maass_lift_preimage_func = ring.type()._maass_generator_preimages
+                
+    lift_polys = []; preims = []
+    monomials = set()
+    
+    for k in xrange(min((weight // 2) - ((weight // 2) % 2), weight - 4), 3, -2) :
+        if k not in subspaces :
+            subspaces[k] = ring.graded_submodule(k)
+        if weight - k not in subspaces :
+            subspaces[weight - k] = ring.graded_submodule(weight - k)
+        
+        try :
+            kgs = zip(subspaces[k].maass_space()._provided_basis(), maass_lift_preimage_func(k))
+            ogs = zip(subspaces[weight - k].maass_space()._provided_basis(), maass_lift_preimage_func(weight - k))
+        except ValueError :
+            continue
+        
+        for f_coords,f_pre in kgs :
+            for g_coords,g_pre in ogs :
+                assert f_coords.parent().graded_ambient() is ring
+                assert g_coords.parent().graded_ambient() is ring
+ 
+                f = ring(f_coords)
+                g = ring(g_coords)
+                    
+                fg_poly = (f*g)._reduce_polynomial()
+                monomials = monomials.union(set(fg_poly.monomials()))
+                
+                M = matrix( QQ, len(lift_polys) + 1,
+                            [ poly.monomial_coefficient(m)
+                              for poly in lift_polys + [fg_poly]
+                              for m in monomials] )
+                
+                # TODO : Use linbox
+                try :
+                    if magma(M).Rank() <= len(lift_polys) :
+                        continue
+                except TypeError :
+                    for i in xrange(10) :
+                        Mp = matrix(Qp(random_prime(10**10), 10), M)
+                        if Mp.rank() > len(lift_polys) : break
+                    else :
+                        if lazy_rank_check :
+                            continue
+                        elif M.rank() <= len(lift_polys) :
+                            continue
+                
+                lift_polys.append(fg_poly)
+                preims.append([f_pre, g_pre])
+                        
+                if len(lift_polys) == dim :
+                    break
+                
+    if len(lift_polys) == dim :
+        ss = construct_from_maass_products(ring, weight, zip(preims, lift_polys), True, False, True)
+        poly_coords = [[0]*i + [1] + (len(lift_polys) - i - 1)*[0] for i in xrange(len(lift_polys))]
+    else :
+        # The products of two Maass lifts don't span this space
+        # we hence have to consider the Maass lifts
+        ss = ring.graded_submodule(weight)
+        poly_coords = [ss.coordinates(ring(p)) for p in lift_polys]
+
+    maass_lifts = maass_lift_func(weight, precision)
+    preims[0:0] = [[p] for p in maass_lift_preimage_func(weight)]
+    all_coords = map(ss.coordinates, maass_lifts) + poly_coords
+    
+    M = matrix(QQ, all_coords).transpose()
+
+    nmb_mls = len(maass_lifts)
+    for i in xrange(10) :
+        Mp = matrix(Qp(random_prime(10**10), 10), M)
+        pvs = Mp.pivots()
+        if pvs[:nmb_mls] == range(nmb_mls) and \
+           len(pvs) == dim :
+            break
+    else :
+        pvs = M.pivots()
+        
+
+    if len(pvs) == dim :
+        return [(preims[i], ring(ss(all_coords[i])).polynomial()) for i in pvs]
+    else :        
+        raise RuntimeError, "The products of at most two Maass lifts don't span " + \
+                            "this space"
+
+def construct_from_maass_products(ring, weight, products, is_basis = True,
+                                  provides_maass_spezialschar = False,
+                                  is_integral = False,
+                                  lazy_rank_check = True) :
+    r"""
+    Pass the return value of spanning_maass_products of a space of Siegel modular
+    forms of same type. This will return a space using these forms.
+    Whenever ``is_basis`` is False the the products are first filtered to yield a
+    basis.
+    """
+    assert QQ.has_coerce_map_from(ring.base_ring()) or ring.base_ring() is ZZ, \
+           "%s doesn't have rational base field" % ring
+           
+    dim = ring.graded_submodule(weight).dimension()
+
+    ## if the products don't provide a basis, we have to choose one
+    if not is_basis :
+        ## we prefer to use Maass lifts, since they are very cheap
+        maass_forms = []; non_maass_forms = []
+        for p in products :
+            if len(p[0]) == 1 :
+                maass_forms.append(p)
+            else :
+                non_maass_forms.append(p)
+        
+        
+        monomials = set()
+        lift_polys = []
+        products = []
+        for lifts, lift_poly in maass_forms + non_maass_forms :
+            red_poly = ring(ring.relations().ring()(lift_poly))._reduce_polynomial()
+            monomials = monomials.union(set(red_poly.monomials()))
+                
+            M = matrix( QQ, len(lift_polys) + 1,
+                        [ poly.monomial_coefficient(m)
+                          for poly in lift_polys + [lift_poly]
+                          for m in monomials] )                
+                                    
+            # TODO : Use linbox
+            try :
+                if magma(M).Rank() > len(lift_polys) :
+                    break
+            except TypeError :
+                for i in xrange(10) :
+                    Mp = matrix(Qp(random_prime(10**10), 10), M)
+                    if Mp.rank() > len(lift_polys) : break
+                else :
+                    if lazy_rank_check :
+                        continue
+                    elif M.rank() <= len(lift_polys) :
+                        continue
+                    
+            lift_polys.append(red_poly)
+            products.append((lifts, red_poly))
+
+            if len(products) == dim :
+                break
+        else :
+            raise ValueError, "products don't provide a basis"
+    
+    basis = []
+     
+    if provides_maass_spezialschar :
+        maass_form_indices = []
+    for i, (lifts, lift_poly) in enumerate(products) :
+        e = ring(ring.relations().ring()(lift_poly))
+
+        if len(lifts) == 1 :
+            l = lifts[0]
+            e._set_fourier_expansion(
+                SiegelModularFormG2MaassLift(l[0], l[1], ring.fourier_expansion_precision(),
+                                             is_integral = is_integral) )
+        elif len(lifts) == 2 :
+            (l0, l1) = tuple(lifts)
+            e._set_fourier_expansion(
+                EquivariantMonoidPowerSeries_LazyMultiplication(
+                    SiegelModularFormG2MaassLift(l0[0], l0[1], ring.fourier_expansion_precision(),
+                                                 is_integral = is_integral),
+                    SiegelModularFormG2MaassLift(l1[0], l1[1], ring.fourier_expansion_precision(),
+                                                 is_integral = is_integral) ) ) 
+
+        else :
+            e._set_fourier_expansion( 
+                prod( SiegelModularFormG2MaassLift(l[0], l[1], ring.precision(),
+                                                   is_integral = is_integral)
+                      for l in lifts) )            
+        basis.append(e)
+        
+        if provides_maass_spezialschar and len(lifts) == 1 :
+            maass_form_indices.append(i)
+    
+    ss = ring._submodule(basis, grading_indices = (weight,), is_heckeinvariant = True)
+    if provides_maass_spezialschar : 
+        maass_coords = [ ss([0]*i + [1] + [0]*(dim-i-1))
+                         for i in maass_form_indices ]
+        ss.maass_space.set_cache( 
+          SiegelModularFormG2Submodule_maassspace(ss, map(ss, maass_coords)) )
+                                 
+    return ss

--- a/psage/modform/paramodularforms/siegelmodularformg2_misc_cython.pyx
+++ b/psage/modform/paramodularforms/siegelmodularformg2_misc_cython.pyx
@@ -1,0 +1,119 @@
+r"""
+Various functions needed for some calculations in the package.
+
+AUTHORS:
+
+- Martin Raum (2009 - 08 - 27) Initial version
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2009 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+include "sage/ext/interrupt.pxi"
+include 'sage/ext/stdsage.pxi'
+include "sage/ext/cdefs.pxi"
+include 'sage/ext/gmp.pxi'
+
+from sage.rings.integer cimport Integer
+
+cpdef divisor_dict(int precision) :
+    r"""
+    Return a dictionary of assigning to each `k <` ``precision`` a list of its divisors.
+    
+    INPUT :
+    
+    - precision    -- a positive integer
+    """
+    cdef int k
+    cdef int l
+    cdef int maxl
+    cdef int divisor
+    
+    cdef mpz_t tmp
+    
+    mpz_init(tmp)
+    
+    mpz_set_si(tmp, precision)
+    mpz_sqrt(tmp, tmp)
+    bound = mpz_get_si(tmp) + 1
+    
+    mpz_clear(tmp)
+    
+    div_dict = PY_NEW(dict)
+    
+    # these are the trivial divisors
+    div_dict[1] = [1]
+    for k from 2 <= k < precision :
+        div_dict[k] = [1,k]
+        
+    for k from 2 <= k < bound // 2 :
+        divisor = 2*k
+        
+        for l from 2 <= l < bound // k :
+            (<list>(div_dict[divisor])).append(k)
+            divisor += k
+
+    return div_dict
+    
+cpdef negative_fundamental_discriminants(int precision) :
+    r"""
+    Return a list of all negative fundamental discriminants `> -precision`
+    """
+    cdef int *markers = <int *>malloc(precision * sizeof(int))
+    cdef int k
+    cdef int maxh
+    cdef int hs
+
+    cdef int tmp
+    cdef mpz_t mpz_tmp
+            
+    mpz_init(mpz_tmp)
+    
+    _sig_on
+    ## consider congruences mod 4
+    for k from 1 <= k < precision :
+        tmp = k % 16
+        if tmp == 3 or tmp == 7 or tmp == 11 or tmp == 15 or tmp == 4 or tmp == 8 :
+            markers[k] = 1
+        else :
+            markers[k] = 0
+
+    mpz_set_si(mpz_tmp, precision)
+    mpz_sqrt(mpz_tmp, mpz_tmp)
+    maxh = mpz_get_si(mpz_tmp)
+        
+    ## consider square divisors
+    for h from 3 <= h < maxh :
+        hs = h*h 
+        tmp = 0
+        
+        for k from 1 <= k < precision // hs :
+            tmp += hs
+            markers[tmp] = 0
+        
+    fund_discs = PY_NEW(list)
+    for k from 2 <= k < precision :
+        if markers[k] :
+            fund_discs.append(-k)
+    _sig_off
+    
+    mpz_clear(mpz_tmp)
+                
+    return fund_discs
+ 

--- a/psage/modform/paramodularforms/siegelmodularformg2_submodule.py
+++ b/psage/modform/paramodularforms/siegelmodularformg2_submodule.py
@@ -1,0 +1,91 @@
+r"""
+Abstract subspaces of Siegel modular forms.
+
+AUTHORS:
+
+- Martin Raum (2009 - 08 - ??) Initial version
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2009 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_submodule import GradedExpansionSubmoduleVector_generic
+from psage.modform.fourier_expansion_framework.modularforms.modularform_submodule import ModularFormsSubmodule_singleweight_ambient_pid, \
+                                               ModularFormsSubmodule_heckeinvariant_submodule
+from sage.misc.cachefunc import cached_method
+
+#===============================================================================
+# DiscrimiantPrecisionSubmodule_abstract
+#===============================================================================
+
+class DiscrimiantPrecisionSubmodule_abstract :
+    def _minimal_discriminant_precision(self, minimal_precision = 0, lazy_rank_check = False) :
+        last_precision = None
+        for p in xrange(minimal_precision, self.graded_ambient().precision().discriminant() + 1) :
+            precision = self.graded_ambient().fourier_ring().filter(p)
+            if not precision < last_precision : continue
+             
+            if self._check_precision(self, precision, lazy_rank_check) :
+                return precision
+        else :
+            raise ValueError( "This basis is not determined completely by its Fourier expansions." )
+
+class SiegelModularFormG2WeightSubmodule_class ( ModularFormsSubmodule_singleweight_ambient_pid,
+                                                 DiscrimiantPrecisionSubmodule_abstract ) :
+    @cached_method
+    def maass_space(self) :
+        return SiegelModularFormG2Submodule_maassspace(
+            self, map(self, self.graded_ambient().type(). \
+                            _maass_generators( self.weight(),
+                                               self.graded_ambient().fourier_expansion_precision())) )    
+    
+class SiegelModularFormG2Submodule_maassspace (
+        ModularFormsSubmodule_heckeinvariant_submodule, DiscrimiantPrecisionSubmodule_abstract ) :
+ 
+    def __init__(self, ambient, basis, **kwds) :
+        self.__provided_basis = basis
+        ModularFormsSubmodule_heckeinvariant_submodule.__init__(self, ambient, basis, **kwds)
+    
+    def weight(self) :
+        return self.ambient_module().weight()
+
+    def _provided_basis(self) :
+        return self.__provided_basis
+
+class SiegelModularFormG2SubmoduleVector_generic ( GradedExpansionSubmoduleVector_generic ) :
+
+    def is_cusp_form(self) :
+        r"""
+        Check wheater self is a cusp form or not.
+        """
+        if self.parent().ring().type().group() != "Sp(2,ZZ)" :
+            raise NotImplementedError
+        
+        try :
+            weight = self.parent().weight() 
+        except AttributeError :
+            raise TypeError, "Can check cusps only for spaces of homogeneous weight"
+        
+        neccessary_precision = weight // 12 + 1 if weight % 12 != 2 \
+                                                else weight // 12
+        if self.parent().ring().fourier_expansion_precision()._indefinite_content_bound() < neccessary_precision :
+            raise ValueError, "the parents precision doesn't suffice"
+        
+        evc = self.fourier_expansion()
+        return all([evc[(0,0,l)] == 0 for l in xrange(neccessary_precision)])

--- a/psage/modform/paramodularforms/siegelmodularformg2_types.py
+++ b/psage/modform/paramodularforms/siegelmodularformg2_types.py
@@ -1,0 +1,412 @@
+r"""
+Types of Siegel modular forms of genus 2.
+
+AUTHORS:
+
+- Martin Raum (2009 - 08 - 03) Initial version.
+- Martin Raum (2010 - 03 - 16) Added types for vector valued forms.
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2009 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.fourier_expansion_framework.gradedexpansions.gradedexpansion_grading import DegreeGrading
+from psage.modform.fourier_expansion_framework.modularforms.modularform_ambient import ModularFormsRing_withheckeaction,\
+                                             ModularFormsModule_generic
+from psage.modform.fourier_expansion_framework.modularforms.modularform_types import ModularFormType_abstract
+from operator import xor
+from sage.categories.number_fields import NumberFields
+from sage.misc.cachefunc import cached_method
+from sage.modular.modform.constructor import ModularForms
+from sage.rings.arith import bernoulli
+from sage.rings.integer_ring import ZZ
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.rational_field import QQ
+from sage.structure.sequence import Sequence
+from psage.modform.paramodularforms.siegelmodularformg2_element import SiegelModularFormG2_classical, SiegelModularFormG2_vectorvalued
+from psage.modform.paramodularforms.siegelmodularformg2_fegenerators import SiegelModularFormG2MaassLift
+from psage.modform.paramodularforms.siegelmodularformg2vv_fegenerators import SiegelModularFormG2SatohBracket
+from psage.modform.paramodularforms.siegelmodularformg2_fourierexpansion import SiegelModularFormG2Filter_discriminant
+from psage.modform.paramodularforms.siegelmodularformg2_heckeaction import SiegelModularFormG2FourierExpansionHeckeAction
+from psage.modform.paramodularforms.siegelmodularformg2_submodule import SiegelModularFormG2WeightSubmodule_class, \
+                                          SiegelModularFormG2SubmoduleVector_generic
+
+#===============================================================================
+# SiegelModularFormsG2
+#===============================================================================
+
+_siegelmodularforms_cache = dict()
+
+def SiegelModularFormsG2(A, type, precision, *args, **kwds) :
+    r"""
+    TESTS:
+    
+    Some brief tests to check that the classical modular forms and the Hecke action work.
+    
+    ::
+    
+        sage: from psage.modform.paramodularforms import SiegelModularFormsG2, SiegelModularFormG2_Classical_Gamma
+        sage: sr = SiegelModularFormsG2(QQ, SiegelModularFormG2_Classical_Gamma(), 200)
+        sage: sr.0         
+        Graded expansion I4
+        sage: sr.gens()   
+        (Graded expansion I4, Graded expansion I6, Graded expansion I10, Graded expansion I12)
+        sage: sr.2.fourier_expansion().coefficients()[(1,1,32)]
+        319360
+        sage: sr.weights()
+        [4, 6, 10, 12]
+        sage: map(sr, sr.graded_submodule(20).basis()) 
+        [Graded expansion I4^5, Graded expansion I4^2*I6^2, Graded expansion I4^2*I12, Graded expansion I4*I6*I10, Graded expansion I10^2]
+        sage: sr.graded_submodule(26).hecke_eigenforms(2)
+        [Graded expansion I4^5*I6 + 265000/392931*I4^2*I6^3 - 1437170847265656463317060480000/19802288209643185928499101*I4^4*I10 - 71078691383556603157606297600000/1524776192142525316494430777*I4*I6^2*I10 - 1984664637742925286551976960000/19802288209643185928499101*I4^2*I6*I12 + 175115938885406662127531537203200000/217825170306075045213490111*I6*I10^2 + 75976549463485417333446829670400000/19802288209643185928499101*I4*I10*I12, Graded expansion I4^4*I10 - 1255/973*I4*I6^2*I10 + 390/973*I4^2*I6*I12 - 4438886400/973*I6*I10^2 + 561116160/139*I4*I10*I12, Graded expansion I4^4*I10 - 31/22*I4*I6^2*I10 + 3/22*I4^2*I6*I12 + 6903360/11*I6*I10^2 + 48304512/11*I4*I10*I12, Graded expansion I4^5*I6 - I4^2*I6^3 - 60187630099968/579984481*I4^4*I10 + 660226634035200/6379829291*I4*I6^2*I10 + 310518955994112/6379829291*I4^2*I6*I12 - 15571964273098752000/6379829291*I6*I10^2 - 14567211596670566400/6379829291*I4*I10*I12, Graded expansion I4^4*I10 + (3551/1520783457816268800*a4^2 - 7540557907/31682988704505600*a4 + 10297152853879/2750259436155)*I4*I6^2*I10 + (-13/3448488566476800*a4^2 + 27240601/71843511801600*a4 - 45812312422/6236415955)*I4^2*I6*I12 + (-98507/2095435760880*a4^2 + 204121897999/43654911685*a4 - 766406631173075712/8730982337)*I6*I10^2 + (6301/997826552800*a4^2 - 42899467371/62364159550*a4 + 89460377464535424/6236415955)*I4*I10*I12]
+    
+    The vector valued Siegel modular forms are implemented quite roughly.
+    
+    ::
+    
+        sage: from psage.modform.paramodularforms import SiegelModularFormsG2, SiegelModularFormG2_VectorValuedW2_Gamma
+        sage: sf = SiegelModularFormsG2(QQ, SiegelModularFormG2_VectorValuedW2_Gamma(), 20)
+        sage: sf.0
+        Graded expansion vector (1, 0, 0, 0, 0, 0)
+        sage: sf.0.fourier_expansion().coefficients()
+        {(1, 0, 3): 56198016*x^2 - 370758528*y^2, (0, 0, 9): -16364592*x^2, (0, 0, 8): 12165120*x^2, (0, 0, 11): 76984128*x^2, (1, 0, 1): -30240*x^2 - 30240*y^2, (0, 0, 12): -53415936*x^2, (0, 0, 7): -2411136*x^2, (1, 0, 4): 910465920*x^2 - 4281167520*y^2, (0, 0, 6): -870912*x^2, (0, 0, 5): 695520*x^2, (0, 0, 4): -211968*x^2, (0, 0, 3): 36288*x^2, (0, 0, 2): -3456*x^2, (2, 0, 2): 202023360*x^2 + 202003200*y^2, (0, 0, 1): 144*x^2, (0, 0, 0): 0, (2, 1, 2): 104686848*x^2 + 122863104*x*y + 108476928*y^2, (1, 1, 1): -4032*x^2 - 4032*x*y - 4032*y^2, (2, 2, 2): 1886976*x^2 - 169344*x*y + 35332416*y^2, (1, 1, 3): -22680000*x^2 - 176904000*x*y - 176904000*y^2, (1, 1, 4): -104799744*x^2 - 2477454336*x*y - 2477454336*y^2, (1, 1, 2): -317952*x^2 - 3787776*x*y - 3787776*y^2, (1, 1, 5): -76507200*x^2 - 18406059840*x*y - 18406059840*y^2, (1, 0, 2): 1669248*x^2 - 11866176*y^2, (0, 0, 10): -16692480*x^2}
+    """
+    global _siegelmodularforms_cache
+    k = (A, type, precision)
+    try :
+        return _siegelmodularforms_cache[k]
+    except KeyError :
+        if isinstance(type, SiegelModularFormG2_Classical_Gamma) :
+            precision = SiegelModularFormG2Filter_discriminant(precision)
+            R = ModularFormsRing_withheckeaction(A, type, precision)
+        elif isinstance(type, SiegelModularFormG2_VectorValuedW2_Gamma) :
+            precision = SiegelModularFormG2Filter_discriminant(precision)
+            R = ModularFormsModule_generic(A, type, precision)
+        else :
+            raise TypeError, "%s must be an Siegel modular form type" % type
+                
+        _siegelmodularforms_cache[k] = R
+        return R
+
+
+#===============================================================================
+# SiegelModularFormG2_Classical_Gamma
+#===============================================================================
+
+class SiegelModularFormG2_Classical_Gamma ( ModularFormType_abstract ) :
+    def __init__(self) :
+        ModularFormType_abstract.__init__(self)
+    
+    def _ambient_construction_function(self) :
+        return SiegelModularFormsG2
+    
+    def _ambient_element_class(self) :
+        return SiegelModularFormG2_classical
+    
+    def _space_element_class(self) :
+        return SiegelModularFormG2SubmoduleVector_generic
+    
+    def _weight_submodule_class(self) :
+        return SiegelModularFormG2WeightSubmodule_class
+        
+    def group(self) :
+        return "Sp(2,ZZ)"
+
+    def _I4(self, precision) :
+        E4 = ModularForms(1,4).gen(0)
+            
+        return SiegelModularFormG2MaassLift(lambda p: 60*(E4.qexp(p)), 0, precision, True, weight = 4)
+
+    def _I6(self, precision) :
+        E6 = ModularForms(1,6).gen(0)
+
+        return SiegelModularFormG2MaassLift(lambda p: -84*(E6.qexp(p)), 0, precision, True, weight = 6)
+
+    def _I10(self, precision) :
+        # we use a standard generator, since its evaluation is much faster
+        Delta = ModularForms(1,12).gen(0)
+        assert Delta == ModularForms(1,12).cuspidal_subspace().gen(0)
+        
+        return SiegelModularFormG2MaassLift(0, lambda p: -(Delta.qexp(p)), precision, True, weight = 10)
+        
+    def _I12(self, precision) :
+        Delta = ModularForms(1,12).gen(0)
+        assert Delta == ModularForms(1,12).cuspidal_subspace().gen(0)
+
+        return SiegelModularFormG2MaassLift(lambda p: Delta.qexp(p), 0, precision, True, weight = 12)
+
+    def generators(self, K, precision) :
+        if K is QQ or K in NumberFields() :            
+            return Sequence([ self._I4(precision), self._I6(precision),
+                              self._I10(precision), self._I12(precision) ])
+            
+        raise NotImplementedError
+
+    def grading(self, K) :
+        if K is QQ or K in NumberFields() :
+            return DegreeGrading([4,6,10,12])
+        
+        raise NotImplementedError    
+
+    def __maass_lifts(self, k, precision, return_value) :
+        r"""
+        Return the Fourier expansion of all Maass forms of weight `k`.
+        """
+        result = []
+        
+        if k < 4 or k % 2 != 0 :
+            return []
+                
+        mf = ModularForms(1,k).echelon_basis()
+        cf = ModularForms(1,k + 2).echelon_basis()[1:]
+        integrality_factor = 2*k * bernoulli(k).denominator()
+
+        for c in [(integrality_factor * mf[0],0)] \
+                     + [ (f,0) for f in mf[1:] ] + [ (0,g) for g in cf ] :
+            if return_value == "lifts" :
+                result.append(SiegelModularFormG2MaassLift(c[0],c[1], precision, True))
+            else :
+                result.append(c)
+        
+        return result
+        
+    def _maass_generators(self, k, precision) :
+        return self.__maass_lifts(k, precision, "lifts")
+    
+    def _maass_generator_preimages(self, k) :
+        return self.__maass_lifts(k, 0, "preimages")        
+    
+    def _generator_names(self, K) :
+        return ["I4", "I6", "I10", "I12"]
+    
+    def _generator_by_name(self, K, name) :
+        if K is QQ or K in NumberFields() :
+            R = self.generator_relations(K).ring()
+            if name == "I4" : return R.gen(0)
+            elif name == "I6" : return R.gen(1)
+            elif name == "I10" : return R.gen(2)
+            elif name == "I12" : return R.gen(3)
+            
+            raise ValueError, "name %s doesn't exist for %s" % (name, K)
+            
+        raise NotImplementedError
+        
+    @cached_method
+    def generator_relations(self, K) :
+        r"""
+        An ideal `I` in a polynomial ring `R`, such that the associated ring
+        is `R / I`. This ideal must be unique for `K`. 
+        """
+        if K is QQ or K in NumberFields() :
+            R = PolynomialRing(K, self._generator_names(K))
+            return R.ideal(0)
+            
+        raise NotImplementedError
+    
+    def weights(self, K) :
+        r"""
+        A list of integers corresponding to the weights.
+        """
+        if K is QQ or K in NumberFields() :
+            return [4,6,10,12]
+        
+        raise NotImplementedError
+
+    def non_vector_valued(self) :
+        r"""
+        Return the non vector values version of this type. 
+        """
+        return self
+        
+    def vector_valued(self) :
+        r"""
+        Return the vector values version of this type.
+        """
+        raise NotImplementedError    
+
+    def has_hecke_action(self) :
+        return True
+    
+    def graded_submodules_are_free(self) :
+        return True
+    
+    def _hecke_operator_class(self) :
+        return SiegelModularFormG2FourierExpansionHeckeAction
+    
+    def __cmp__(self, other) :
+        return cmp(type(self), type(other))
+
+    def __hash__(self) :
+        return xor(hash(type(self)), hash(self.grading(QQ)))
+
+#===============================================================================
+# SiegelModularFormG2_VectorValuedW2_Gamma
+#===============================================================================
+
+class SiegelModularFormG2_VectorValuedW2_Gamma ( ModularFormType_abstract ) :
+    def __init__(self) :
+        ModularFormType_abstract.__init__(self)
+    
+    def _ambient_construction_function(self) :
+        return SiegelModularFormsG2 
+ 
+    def _ambient_element_class(self) :
+        return SiegelModularFormG2_vectorvalued
+    
+    def _space_element_class(self) :
+        return SiegelModularFormG2SubmoduleVector_generic
+    
+    def group(self) :
+        return "Sp(2,ZZ)"
+
+    def _I4(self, precision) :
+        E4 = ModularForms(1,4).gen(0)
+            
+        return SiegelModularFormG2MaassLift(lambda p: 60*(E4.qexp(p)), 0, precision, True, weight = 4)
+ 
+    def _I6(self, precision) :
+        E6 = ModularForms(1,6).gen(0)
+ 
+        return SiegelModularFormG2MaassLift(lambda p: -84*(E6.qexp(p)), 0, precision, True, weight = 6)
+ 
+    def _I10(self, precision) :
+        # we use a standard generator, since its evaluation is much faster
+        Delta = ModularForms(1,12).gen(0)
+        assert Delta == ModularForms(1,12).cuspidal_subspace().gen(0)
+        
+        return SiegelModularFormG2MaassLift(0, lambda p: -(Delta.qexp(p)), precision, True, weight = 10)
+        
+    def _I12(self, precision) :
+        Delta = ModularForms(1,12).gen(0)
+        assert Delta == ModularForms(1,12).cuspidal_subspace().gen(0)
+ 
+        return SiegelModularFormG2MaassLift(lambda p: Delta.qexp(p), 0, precision, True, weight = 12)
+
+    def _satoh_I4_I6(self, precision) :
+        return SiegelModularFormG2SatohBracket(self._I4(precision), self._I6(precision), 4, 6)
+
+    def _satoh_I4_I10(self, precision) :
+        return SiegelModularFormG2SatohBracket(self._I4(precision), self._I10(precision), 4, 10)
+    
+    def _satoh_I4_I12(self, precision) :
+        return SiegelModularFormG2SatohBracket(self._I4(precision), self._I12(precision), 4, 12)
+
+    def _satoh_I6_I10(self, precision) :
+        return SiegelModularFormG2SatohBracket(self._I6(precision), self._I10(precision), 6, 10)
+
+    def _satoh_I6_I12(self, precision) :
+        return SiegelModularFormG2SatohBracket(self._I6(precision), self._I12(precision), 6, 12)
+
+    def _satoh_I10_I12(self, precision) :
+        return SiegelModularFormG2SatohBracket(self._I10(precision), self._I12(precision), 10, 12)
+
+    def base_ring_generators(self, K, precision) :
+        if K is QQ or K in NumberFields() :            
+            return Sequence([ self._I4(precision), self._I6(precision),
+                              self._I10(precision), self._I12(precision) ])
+        raise NotImplementedError
+
+    def generators(self, K, precision) :
+        if K is QQ or K in NumberFields() :
+            return Sequence([ self._satoh_I4_I6(precision), self._satoh_I4_I10(precision),
+                              self._satoh_I4_I12(precision), self._satoh_I6_I10(precision),
+                              self._satoh_I6_I12(precision), self._satoh_I10_I12(precision) ])
+        
+        raise NotImplementedError            
+
+    def grading(self, K) :
+        if K is QQ or K in NumberFields() :
+            return DegreeGrading([4,6,10,12, 10,14,16,16,18,22])
+        
+        raise NotImplementedError    
+        
+    def _generator_names(self, K) :
+        if K is QQ or K in NumberFields() :
+            return [ "I4", "I6", "I10", "I12", "SB_I4_I6", "SB_I4_I10",
+                     "SB_I4_I12", "SB_I6_I10", "SB_I6_I12", "SB_I10_I12" ]
+    
+    def _generator_by_name(self, K, name) :
+        if K is QQ or K in NumberFields() :
+            R = self.generator_relations(K).ring()
+            try :
+                i = self._generator_names(K).index(name)
+                return R.gen(i)
+            except ValueError:
+                raise ValueError, "name %s doesn't exist for %s" % (name, K)
+
+            #===================================================================
+            # if name == "I4" : return R.gen(0)
+            # elif name == "I6" : return R.gen(1)
+            # elif name == "I10" : return R.gen(2)
+            # elif name == "I12" : return R.gen(3)
+            # elif name == "SB_I4_I6" : return R.gen(4)
+            # elif name == "SB_I4_I10" : return R.gen(5)
+            # elif name == "SB_I4_I12" : return R.gen(6)
+            # elif name == "SB_I6_I10" : return R.gen(7)
+            # elif name == "SB_I6_I12" : return R.gen(8)
+            # elif name == "SB_I10_I12" : return R.gen(9)
+            #===================================================================
+            
+        raise NotImplementedError
+        
+    @cached_method
+    def generator_relations(self, K) :
+        r"""
+        An ideal `I` in a polynomial ring `R`, such that the associated ring
+        is `R / I`. This ideal must be unique for `K`. 
+        """
+        if K is QQ or K in NumberFields() :
+            R = PolynomialRing(K, self._generator_names(K))
+            ##FIXME: There are relations. Find and implement them.
+            return R.ideal(0)
+            
+        raise NotImplementedError
+    
+    def weights(self, K) :
+        r"""
+        A list of integers corresponding to the weights.
+        """
+        if K is QQ or K in NumberFields() :
+            return [10,14,16,16,18,22]
+        
+        raise NotImplementedError
+
+    def is_vector_valued(self) :
+        return True
+
+    def non_vector_valued(self) :
+        r"""
+        Return the non vector values version of this type. 
+        """
+        return SiegelModularFormG2_Classical_Gamma()
+        
+    def vector_valued(self) :
+        r"""
+        Return the vector values version of this type.
+        """
+        raise self
+
+    def graded_submodules_are_free(self) :
+        return True
+
+    def __cmp__(self, other) :
+        return cmp(type(self), type(other))
+    
+    def __hash__(self) :
+        return xor(hash(type(self)), hash(self.grading(QQ)))

--- a/psage/modform/paramodularforms/siegelmodularformg2vv_fegenerators.py
+++ b/psage/modform/paramodularforms/siegelmodularformg2vv_fegenerators.py
@@ -1,0 +1,136 @@
+r"""
+Generator functions for the Fourier expansion of vector valued Siegel modular forms. 
+
+AUTHORS:
+
+- Martin Raum (2010 - 05 - 12) Initial version
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.paramodularforms.siegelmodularformg2_fourierexpansion import SiegelModularFormG2VVFourierExpansionRing
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ambient import EquivariantMonoidPowerSeriesAmbient_abstract
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_lazyelement import EquivariantMonoidPowerSeries_lazy
+from psage.modform.paramodularforms.siegelmodularformg2vv_fegenerators_cython import satoh_dz
+
+#===============================================================================
+# SiegelModularFormG2SatohBracket
+#===============================================================================
+
+def SiegelModularFormG2SatohBracket(f, g, f_weight = None, g_weight = None) :
+    r"""
+    INPUT:
+    
+    - `f` -- Fourier expansion of a classical Siegel modular form.
+    
+    - `g` -- Fourier expansion of a classical Siegel modular form.
+    
+    - ``f_weight`` -- the weight of `f` (default: ``None``).
+     
+    - ``g_weight`` -- the weight of `g` (default: ``None``).
+    
+    OUTPUT:
+    
+    - The Fourier expansion of a vector-valued Siegel modular form.
+    """        
+    if f_weight is None :
+        f_weight = f.weight()
+    if g_weight is None :
+        g_weight = g.weight()
+    
+    if not isinstance(f.parent(), EquivariantMonoidPowerSeriesAmbient_abstract) :
+        f = f.fourier_expansion()
+    if not isinstance(g.parent(), EquivariantMonoidPowerSeriesAmbient_abstract) :
+        g = g.fourier_expansion()
+        
+    if f.parent() != g.parent() :
+        if f.parent().has_coerce_map_from(g.parent()) :
+            g = f.parent()(g)
+        elif g.parent().has_coerce_map_from(f.parent()) :
+            f = g.parent()(f)
+        else :
+            from sage.categories.pushout import pushout
+            parent = pushout(f.parent(), g.parent())
+            f = parent(f)
+            g = parent(g)
+            
+    precision = min(f.precision(), g.precision())
+    
+    expansion_ring = SiegelModularFormG2VVFourierExpansionRing(
+                                            f.parent().coefficient_domain().fraction_field() )
+    coefficients_factory = DelayedFactory_SMFG2_satohbracket(
+                             f, g, f_weight, g_weight, expansion_ring.coefficient_domain() )
+
+    return EquivariantMonoidPowerSeries_lazy( expansion_ring, precision,
+                                              coefficients_factory.getcoeff )
+
+#===============================================================================
+# DelayedFactory_SMFG2_satohbracket
+#===============================================================================
+
+class DelayedFactory_SMFG2_satohbracket :
+    def __init__( self, f, g, f_weight, g_weight, coefficient_domain ) :
+        self.__f = f
+        self.__g = g
+        self.__f_weight = f_weight
+        self.__g_weight = g_weight
+        self.__coefficient_domain = coefficient_domain
+        
+        self.__series = None
+    
+    def getcoeff( self, key, **kwds ) :
+        (_, k) = key
+        # for speed we ignore the character 
+        if self.__series is None :
+            self.__series = \
+             _satoh_bracket( self.__f, self.__g,
+                             self.__f_weight, self.__g_weight )
+        
+        return self.__coefficient_domain( self.__series[k] )
+
+def _satoh_bracket(f, g, f_weight, g_weight) :
+    r"""
+    We suppose that `f` and `g` are either contained in a ring of a scalar
+    valued Siegel modular forms or that they are equivariant monoid
+    power series.
+    `f` and `g` must have the same parent after conversion to fourier
+    expansions.
+    
+    OUTPUT:
+    
+    - The return value is a Equivariant monoid power series.
+    """
+    if not f.parent() == g.parent() :
+        raise ValueError, "The fourier expansions of f and g must" + \
+                          " have the same parent"
+
+    base_ring = f.parent().coefficient_domain()
+    if len(f.non_zero_components()) != 1 :
+        raise ValueError, "f must have only one non-vanishing character"
+    if len(g.non_zero_components()) != 1 :
+        raise ValueError, "g must have only one non-vanishing character"
+    
+    fe_ring = SiegelModularFormG2VVFourierExpansionRing(base_ring)
+    R = fe_ring.coefficient_domain()
+            
+    dzf = fe_ring(satoh_dz(f.coefficients(False), R))
+    dzg = fe_ring(satoh_dz(g.coefficients(False), R))
+    
+    return (g * dzf) / f_weight - (f * dzg) / g_weight

--- a/psage/modform/paramodularforms/siegelmodularformg2vv_fegenerators_cython.pyx
+++ b/psage/modform/paramodularforms/siegelmodularformg2vv_fegenerators_cython.pyx
@@ -1,0 +1,50 @@
+r"""
+The diffential operator involved in the definition of the Satoh bracket.
+
+AUTHORS:
+
+- Martin Raum (2010 - 03 - 16) Initial version.
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+include "interrupt.pxi"
+include "stdsage.pxi"
+include "cdefs.pxi"
+
+cpdef satoh_dz(f, R) :
+    ## Satoh's definition of the operation on Siegel modular forms yields
+    ## a polynomial substitution x -> dx - cy, y -> -b + ay.
+    ## We will need x -> ax + by, y -> cx + dy.
+    ## We hence calculate the operator matrix(2, [d z_2, -d z_3 / 2, *, d z_1]) 
+    
+    x = R.gen(0)
+    y = R.gen(1)
+    xsq = x*x
+    xy  = x*y
+    ysq = y*y
+        
+    res = PY_NEW(dict)
+    res2 = PY_NEW(dict)
+    res3 = PY_NEW(dict)
+    for k in f :
+        res[k] = xsq * (k[2] * f[k]) + xy * (k[1] * f[k]) + ysq * (k[0] * f[k])
+
+    return res

--- a/psage/modform/paramodularforms/siegelmodularformg2vv_heckeaction.py
+++ b/psage/modform/paramodularforms/siegelmodularformg2vv_heckeaction.py
@@ -1,0 +1,164 @@
+r"""
+The Hecke action on vector valued Siegel modular forms of genus 2.
+
+AUTHORS:
+
+- Martin Raum (2010 - 05 - 12) Initial version, based on classical case.
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.paramodularforms.siegelmodularformg2_fourierexpansion import SiegelModularFormG2VVRepresentation
+from sage.misc.cachefunc import cached_method
+from sage.misc.latex import latex
+from sage.modular.modsym.p1list import P1List
+from sage.rings.integer import Integer
+from sage.structure.sage_object import SageObject
+from psage.modform.paramodularforms import siegelmodularformg2_misc_cython
+
+_siegelmodularformg2_heckeoperator_cache = dict()
+
+#===============================================================================
+# SiegelModularFormG2FourierExpansionHeckeAction
+#===============================================================================
+
+def SiegelModularFormG2VVFourierExpansionHeckeAction( n ) :
+    global _siegelmodularformg2_heckeoperator_cache
+    
+    try :
+        return _siegelmodularformg2_heckeoperator_cache[n]
+    except KeyError :
+        A = SiegelModularFormG2VVFourierExpansionHeckeAction_class(n)
+        _siegelmodularformg2_heckeoperator_cache[n] = A
+        
+        return A
+
+#===============================================================================
+# SiegelModularFormG2FourierExpansionHeckeAction_class
+#===============================================================================
+
+class SiegelModularFormG2VVFourierExpansionHeckeAction_class (SageObject):
+    r"""
+    Implements a Hecke operator acting on Siegel modular.
+    """
+
+    def __init__(self, n):
+        self.__l = n
+
+        self.__l_divisors = siegelmodularformg2_misc_cython.divisor_dict(n + 1)
+
+    def eval(self, expansion, weight = None) :
+        """
+        INPUT:
+        
+        - ``weight`` -- A pair ``(sym_weight, det_weight)``.
+        """
+        
+        if weight is None :
+            try :
+                (sym_weight, det_weight) = expansion.weight()
+            except AttributeError :
+                raise ValueError, "weight must be defined for the Hecke action"
+        else :
+            (sym_weight, det_weight) = weight
+            
+        precision = expansion.precision()
+        if precision.is_infinite() :
+            precision = expansion._bounding_precision()
+        else :
+            precision = precision._hecke_operator(self.__l)
+        characters = expansion.non_zero_components()
+        
+        hecke_expansion = dict()
+        if isinstance(expansion.parent().representation(), SiegelModularFormG2VVRepresentation) :
+            for ch in characters :
+                hecke_expansion[ch] = dict( (k, self.hecke_coeff_polynomial(expansion, ch, k, sym_weight, det_weight)) for k in precision )
+        else :
+            raise TypeError, "Unknown representation type"
+        
+        result = expansion.parent()._element_constructor_(hecke_expansion)
+        result._set_precision(expansion.precision()._hecke_operator(self.__l))
+        
+        return result
+        
+    def hecke_coeff_polynomial(self, expansion, ch, (a,b,c), j, k) :
+        r"""
+        Computes the coefficient indexed by $(a,b,c)$ of $T(\ell) (F)$
+        """
+        character_eval = expansion.parent()._character_eval_function()
+        x = expansion.parent().coefficient_domain().gen(0)
+        y = expansion.parent().coefficient_domain().gen(1)
+        
+        ell = self.__l
+        coeff = 0
+        for t1 in self.__l_divisors[ell]:
+            for t2 in self.__l_divisors[t1]:
+                for V in self.get_representatives(t1/t2):
+                    aprime, bprime, cprime = self.change_variables(V,(a,b,c))
+                    if aprime % t1 == 0 and bprime % t2 == 0 and cprime % t2 == 0:
+                        try:
+                            coeff = coeff + character_eval(V, ch) * t1**(k-2)*t2**(k-1) * \
+                                            expansion[( ch, ((ell*aprime) //t1**2,
+                                                             (ell*bprime) //t1//t2,
+                                                             (ell*cprime) //t2**2) )] ( ell//t1 * V[0] * x + ell//t1 * V[1] * y,
+                                                                                        ell//t2 * V[2] * x + ell//t2 * V[3] * y )
+                        except KeyError, msg:
+                            raise ValueError, '%s' %(expansion,msg)
+        return coeff
+
+    @cached_method
+    def get_representatives( self, t) :
+        r"""
+        A helper function used in hecke_coeff that computes the right
+        coset representatives of $\Gamma^0(t)\SL(2,Z)$ where
+        $\Gamma^0(t)$ is the subgroup of $SL(2,Z)$ where the upper right hand
+        corner is divisible by $t$.
+
+        NOTE
+            We use the bijection $\Gamma^0(t)\SL(2,Z) \rightarrow P^1(\Z/t\Z)$
+            given by $A \mapsto [1:0]A$.
+        """
+        if t == 1 : return [(1,0,0,1)]
+        
+        rep_list = []
+        
+        for x,y in P1List(t):
+            ## we calculate a pair c,d satisfying a minimality condition
+            ## to make later multiplications cheaper
+            (_, d, c) = Integer(x)._xgcd(Integer(y), minimal=True)
+            rep_list.append((x,y,-c,d))
+                
+        return rep_list
+
+    @staticmethod
+    def change_variables((a,b,c,d), (n,r,m)):
+        r"""
+        A helper function used in hecke_coeff that computes the
+        quadratic form [nprime,rprime,mprime] given by $Q((x,y) V)$
+        where $Q=[n,r,m]$ and $V$ is a 2 by 2 matrix given by (a,b,c,d)
+        """        
+        return ( n*a**2 + r*a*b + m*b**2, 2*(n*a*c + m*b*d) + r*(a*d + c*b), \
+                 n*c**2 + r*c*d + m*d**2 )
+
+    def _repr_(self) :
+        return '%s-th Hecke operator for vector valued Siegel modular forms' % self.__l
+
+    def _latex_(self) :
+        return latex(self.__n) + '-th Hecke operator for vector valued Siegel modular forms'

--- a/psage/modform/paramodularforms/siegelmodularformg4_fourierexpansion.py
+++ b/psage/modform/paramodularforms/siegelmodularformg4_fourierexpansion.py
@@ -1,0 +1,506 @@
+r"""
+Classes describing the Fourier expansion of Siegel modular forms of genus `4`.
+
+AUTHOR :
+    -- Martin Raum (2009 - 05 - 19) Initial version
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from copy import copy
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids \
+              import TrivialCharacterMonoid, TrivialRepresentation
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring \
+              import EquivariantMonoidPowerSeriesRing
+from operator import xor
+from psage.modform.paramodularforms.siegelmodularformgn_fourierexpansion import SiegelModularFormGnFilter_diagonal_lll,\
+    SiegelModularFormGnIndices_diagonal_lll
+from sage.matrix.constructor import diagonal_matrix, matrix, zero_matrix, identity_matrix
+from sage.misc.functional import isqrt
+from sage.misc.latex import latex
+from sage.rings.infinity import infinity
+from sage.rings.integer_ring import ZZ
+
+#===============================================================================
+# SiegelModularFormG4Indices_diagonal_lll
+#===============================================================================
+
+class SiegelModularFormG4Indices_diagonal_lll ( SiegelModularFormGnIndices_diagonal_lll ) :
+    r"""
+    All positive definite quadratic forms filtered by their discriminant.
+    """
+    def __init__(self, reduced = True) :
+        SiegelModularFormGnIndices_diagonal_lll.__init__(self, 4, reduced)
+
+    def monoid(self) :
+        return SiegelModularFormG4Indices_diagonal_lll(False) 
+    
+    def filter(self, bound) :
+        return SiegelModularFormG4Filter_diagonal_lll(bound, self.is_reduced())
+        
+    def filter_all(self) :
+        return SiegelModularFormG4Filter_diagonal_lll(infinity, self.is_reduced())
+        
+    def _reduction_function(self) :
+        return self.reduce
+
+    def decompositions(self, t) :
+        ## We find all decompositions t1 + t2 = t
+        ## We first find possible upper left matrices
+        
+        sub2 = list()
+        for a0 in xrange(0, t[0,0] + 1, 2) :
+            for a1 in xrange(0, t[1,1] + 1, 2) :
+                # obstruction for t1[0,1]
+                B1 = isqrt(a0 * a1)
+                # obstruction for t2[0,1]
+                B2 = isqrt((t[0,0] - a0) * (t[1,1] - a1))
+                
+                for b01 in xrange(max(-B1, t[0,1] - B2), min(B1, t[0,1] + B2) + 1) :
+                    sub2.append((a0,a1,b01))
+        
+        sub3 = list()
+        for (a0, a1, b01) in sub2 :
+            sub3s = list()
+            for a2 in xrange(0, t[2,2] + 1, 2) :
+                # obstruction for t1[0,2]
+                B1 = isqrt(a0 * a2)
+                # obstruction for t2[0,2]
+                B2 = isqrt((t[0,0] - a0) * (t[2,2] - a2))
+                
+                for b02 in xrange(max(-B1, t[0,2] - B2), min(B1, t[0,2] + B2) + 1) :
+                    # obstruction for t1[1,2]
+                    B3 = isqrt(a1 * a2)
+                    # obstruction for t2[1,2]
+                    B4 = isqrt((t[1,1] - a1) * (t[2,2] - a2))
+                    
+                    for b12 in xrange(max(-B3, t[1,2] - B4), min(B3, t[1,2] + B4) + 1) :
+                        # obstruction for the minor [0,1,2] of t1
+                        if a0*a1*a2 - a0*b12**2 + 2*b01*b12*b02 - b01**2*a2 - a1*b02**2 < 0 :
+                            continue
+                        # obstruction for the minor [0,1,2] of t2
+                        if  (t[0,0] - a0)*(t[1,1] - a1)*(t[2,2] - a2) - (t[0,0] - a0)*(t[1,2] - b12)**2 \
+                           + 2*(t[0,1] - b01)*(t[1,2] - b12)*(t[0,2] - b02) - (t[0,1] - b01)**2*(t[2,2] - a2) \
+                           - (t[1,1] - a1)*(t[0,2] - b02)**2 < 0 :
+                            continue
+                        sub3s.append((a2, b02, b12))
+            sub3.append((a0, a1, b01, sub3s))
+
+        for (a0,a1,b01, sub3s) in sub3 :
+            for (a2, b02, b12) in sub3s :
+                for a3 in xrange(0, t[3,3] + 1, 2) :
+                    # obstruction for t1[0,3]
+                    B1 = isqrt(a0 * a3)
+                    # obstruction for t2[0,3]
+                    B2 = isqrt((t[0,0] - a0) * (t[3,3] - a3))
+                
+                    for b03 in xrange(max(-B1, t[0,3] - B2), min(B1, t[0,3] + B2) + 1) :
+                        # obstruction for t1[1,3]
+                        B3 = isqrt(a1 * a3)
+                        # obstruction for t2[1,3]
+                        B4 = isqrt((t[1,1] - a1) * (t[3,3] - a3))
+
+                        for b13 in xrange(max(-B3, t[1,3] - B4), min(B3, t[1,3] + B4) + 1) :
+                            # obstruction for the minor [0,1,3] of t1
+                            if a0*a1*a3 - a0*b13**2 + 2*b01*b13*b03 - b01**2*a3 - a1*b03**2 < 0 :
+                                continue
+                            # obstruction for the minor [0,1,3] of t2
+                            if  (t[0,0] - a0)*(t[1,1] - a1)*(t[3,3] - a3) - (t[0,0] - a0)*(t[1,3] - b13)**2 \
+                               + 2*(t[0,1] - b01)*(t[1,3] - b13)*(t[0,3] - b03) - (t[0,1] - b01)**2*(t[3,3] - a3) \
+                               - (t[1,1] - a1)*(t[0,3] - b03)**2 < 0 :
+                                continue
+                            
+                            # obstruction for t1[2,3]
+                            B3 = isqrt(a2 * a3)
+                            # obstruction for t2[2,3]
+                            B4 = isqrt((t[2,2] - a2) * (t[3,3] - a3))
+                            
+                            for b23 in xrange(max(-B3, t[2,3] - B4), min(B3, t[2,3] + B4) + 1) :
+                                # obstruction for the minor [0,2,3] of t1
+                                if a0*a2*a3 - a0*b23**2 + 2*b02*b23*b03 - b02**2*a3 - a2*b03**2 < 0 :
+                                    continue
+                                # obstruction for the minor [0,2,3] of t2
+                                if  (t[0,0] - a0)*(t[2,2] - a2)*(t[3,3] - a3) - (t[0,0] - a0)*(t[2,3] - b23)**2 \
+                                   + 2*(t[0,2] - b02)*(t[2,3] - b23)*(t[0,3] - b03) - (t[0,2] - b02)**2*(t[3,3] - a3) \
+                                   - (t[2,2] - a2)*(t[0,3] - b03)**2 < 0 :
+                                    continue
+                                
+                                # obstruction for the minor [1,2,3] of t1
+                                if a1*a2*a3 - a1*b23**2 + 2*b12*b23*b13 - b12**2*a3 - a2*b13**2 < 0 :
+                                    continue
+                                # obstruction for the minor [1,2,3] of t2
+                                if  (t[1,1] - a1)*(t[2,2] - a2)*(t[3,3] - a3) - (t[1,1] - a1)*(t[2,3] - b23)**2 \
+                                   + 2*(t[1,2] - b12)*(t[2,3] - b23)*(t[1,3] - b13) - (t[1,2] - b12)**2*(t[3,3] - a3) \
+                                   - (t[2,2] - a2)*(t[1,3] - b13)**2 < 0 :
+                                    continue
+
+                                t1 = matrix(ZZ, 4, [a0, b01, b02, b03, b01, a1, b12, b13, b02, b12, a2, b23, b03, b13, b23, a3], check = False)
+                                if t1.det() < 0 :
+                                    continue
+                                t2 = t - t1
+                                if t2.det() < 0 :
+                                    continue
+                                
+                                t1.set_immutable()
+                                t2.set_immutable()
+                                
+                                yield (t1, t2)
+
+        raise StopIteration
+
+    def __hash__(self) :
+        return hash(self.is_reduced())
+    
+    def _repr_(self) :
+        if self.is_reduced() :
+            return "Reduced quadratic forms of rank 4 over ZZ"
+        else :
+            return "Quadratic forms over of rank 4 ZZ"
+            
+    def _latex_(self) :
+        if self.is_reduced() :
+            return "Reduced quadratic forms of rank $4$ over $\mathbb{Z}$"
+        else :
+            return "Quadratic forms over of rank $4$ over $\mathbb{Z}$"
+
+#===============================================================================
+# SiegelModularFormG4Filter_diagonal_lll
+#===============================================================================
+
+class SiegelModularFormG4Filter_diagonal_lll ( SiegelModularFormGnFilter_diagonal_lll ) :
+    def __init__(self, bound, reduced = True) :
+        SiegelModularFormGnFilter_diagonal_lll.__init__(self, 4, bound, reduced)
+
+    def filter_all(self) :
+        return SiegelModularFormG4Filter_diagonal_lll(infinity, self.is_reduced())
+    
+    def zero_filter(self) :
+        return SiegelModularFormG4Filter_diagonal_lll(0, self.is_reduced()) 
+
+    def _calc_iter_reduced_sub2(self) :
+        try :
+            return self.__iter_reduced_sub2
+        except AttributeError :
+            pass
+        
+        sub2 = list()
+        for a0 in xrange(2, 2 * self.index(), 2) :
+            for a1 in xrange(a0, 2 * self.index(), 2) :
+                # obstruction for t[0,1]
+                B1 = isqrt(a0 * a1 - 1)
+                
+                for b01 in xrange(0, min(B1, a0 // 2) + 1) :
+                    sub2.append((a0,a1,-b01))
+        
+        self.__iter_reduced_sub2 = sub2
+
+        return sub2
+
+    def _calc_iter_reduced_sub3(self) :
+        try :
+            return self.__iter_reduced_sub3
+        except AttributeError :
+            pass
+        
+        sub2 = self._calc_iter_reduced_sub2()
+        
+        sub3 = list()
+        for (a0, a1, b01) in sub2 :
+            sub3s = list()
+            for a2 in xrange(2, 2 * self.index(), 2) :
+                # obstruction for t[0,2]
+                B1 = isqrt(a0 * a2 - 1)
+                
+                for b02 in xrange(-B1, B1 + 1) :
+                    # obstruction for t[1,2]
+                    B3 = isqrt(a1 * a2 - 1)
+                    
+                    for b12 in xrange(-B3, B3 + 1) :
+                        # obstruction for the minor [0,1,2] of t
+                        if a0*a1*a2 - a0*b12**2 + 2*b01*b12*b02 - a2*b01**2 - a1*b02**2 <= 0 :
+                            continue
+                        
+                        t = matrix(ZZ, 3, [a0, b01, b02, b01, a1, b12, b02, b12, a2])
+                        u = t.LLL_gram()
+                        if u.transpose() * t * u != t :
+                            continue
+                        
+                        sub3s.append((a2, b02, b12))
+                        
+            sub3.append((a0, a1, b01, sub3s))
+        
+        self.__iter_reduced_sub3 = sub3
+        
+        return sub3
+
+    def _calc_iter_reduced_sub4(self) :
+        try :
+            return self.__iter_reduced_sub4
+        except AttributeError :
+            pass
+        
+        sub3 = self._calc_iter_reduced_sub3()
+        
+        sub4 = list()
+        for (a0,a1,b01,sub3s) in sub3 :
+            sub4s = list()
+            for (a2, b02, b12) in sub3s :
+                sub4ss = list()
+                for a3 in xrange(2, 2 * self.index() + 1, 2) :
+                    # obstruction for t[0,3]
+                    B1 = isqrt(a0 * a3 - 1)
+                
+                    for b03 in xrange(-B1, B1 + 1) :
+                        # obstruction for t[1,3]
+                        B3 = isqrt(a1 * a3 - 1)
+
+                        for b13 in xrange(-B3, B3 + 1) :
+                            # obstruction for the minor [0,1,3] of t
+                            if a0*a1*a3 - a0*b12**2 + 2*b01*b13*b03 - b01**2*a3 - a1*b03**2 <= 0 :
+                                continue
+                            
+                            # obstruction for t[2,3]
+                            B3 = isqrt(a2 * a3 - 1)
+                            
+                            for b23 in xrange(-B3, B3 + 1) :
+                                # obstruction for the minor [0,2,3] of t
+                                if a0*a2*a3 - a0*b23**2 + 2*b02*b23*b03 - b02**2*a3 - a2*b03**2 <= 0 :
+                                    continue
+                                
+                                # obstruction for the minor [1,2,3] of t
+                                if a1*a2*a3 - a1*b23**2 + 2*b12*b23*b13 - b12**2*a3 - a2*b13**2 <= 0 :
+                                    continue
+
+                                t = matrix(ZZ, 4, [a0, b01, b02, b03, b01, a1, b12, b13, b02, b12, a2, b23, b03, b13, b23, a3], check = False)
+                                if t.det() <= 0 :
+                                    continue
+                                
+                                u = t.LLL_gram()
+                                if u.transpose() * t * u != t :
+                                    continue
+                                                                   
+                                sub4ss.append((a3, b03, b13, b23))
+                sub4s.append((a2, b02, b12, sub4ss))
+            sub4.append((a0, a1, b01, sub4s))
+        
+        self.__iter_reduced_sub4 = sub4
+
+        return sub4
+
+    def __iter__(self) :
+        if self.index() is infinity :
+            raise ValueError, "infinity is not a true filter index"
+
+        if self.is_reduced() :
+            ## We only iterate positive definite matrices
+            ## and later build the semidefinite ones
+            ## We first find possible upper left matrices
+            
+            sub2 = self._calc_iter_reduced_sub2()
+            sub3 = self._calc_iter_reduced_sub3()
+            sub4 = self._calc_iter_reduced_sub4()
+
+                
+            t = zero_matrix(ZZ, 4)
+            t.set_immutable()
+            yield t
+            
+            for a0 in xrange(2, 2 * self.index(), 2) :
+                t = zero_matrix(ZZ, 4)
+                t[3,3] = a0
+                t.set_immutable()
+                
+                yield t
+                
+            for (a0, a1, b01) in sub2 :
+                t = zero_matrix(ZZ, 4)
+                t[2,2] = a0
+                t[3,3] = a1
+                t[2,3] = b01
+                t[3,2] = b01
+                t.set_immutable()
+                
+                yield t
+                
+            for (a0, a1, b01, sub3s) in sub3 :
+                t = zero_matrix(ZZ, 4)
+                t[1,1] = a0
+                t[2,2] = a1
+                t[1,2] = b01
+                t[2,1] = b01
+                
+                for (a2, b02, b12) in sub3s :
+                    ts = copy(t)
+                    ts[3,3] = a2
+                    ts[1,3] = b02
+                    ts[3,1] = b02
+                    ts[2,3] = b12
+                    ts[3,2] = b12
+                    ts.set_immutable()
+                    
+                    yield ts
+                    
+            for (a0, a1, b01, sub4s) in sub4 :
+                t = zero_matrix(ZZ, 4)
+                t[0,0] = a0
+                t[1,1] = a1
+                t[0,1] = b01
+                t[1,0] = b01
+                
+                for (a2, b02, b12, sub4ss) in sub4s :
+                    ts = copy(t)
+                    ts[2,2] = a2
+                    ts[0,2] = b02
+                    ts[2,0] = b02
+                    ts[1,2] = b12
+                    ts[2,1] = b12
+                    
+                    for (a3, b03, b13, b23) in sub4ss :
+                        tss = copy(ts)
+                        tss[3,3] = a3
+                        tss[0,1] = b01
+                        tss[1,0] = b01
+                        tss[0,2] = b02
+                        tss[2,0] = b02
+                        tss[0,3] = b03
+                        tss[3,0] = b03
+                        tss.set_immutable()
+                        
+                        yield tss
+
+        #! if self.is_reduced()
+        else :
+            ## We first find possible upper left matrices
+            
+            sub2 = list()
+            for a0 in xrange(2 * self.index(), 2) :
+                for a1 in xrange(2 * self.index(), 2) :
+                    # obstruction for t[0,1]
+                    B1 = isqrt(a0 * a1)
+                    
+                    for b01 in xrange(-B1, B1 + 1) :
+                        sub2.append((a0,a1,b01))
+                        
+            sub3 = list()
+            for (a0, a1, b01) in sub2 :
+                sub3s = list()
+                for a2 in xrange(2 * self.index(), 2) :
+                    # obstruction for t[0,2]
+                    B1 = isqrt(a0 * a2)
+                    
+                    for b02 in xrange(-B1, B1 + 1) :
+                        # obstruction for t[1,2]
+                        B3 = isqrt(a1 * a2)
+                        
+                        for b12 in xrange(-B3, B3 + 1) :
+                            # obstruction for the minor [0,1,2] of t
+                            if a0*a1*a2 - a0*b12**2 + 2*b01*b12*b02 - b01**2*a2 - a1*b02**2 < 0 :
+                                continue
+                            sub3s.append((a2, b02, b12))
+                sub3.append((a0, a1, b01, sub3s))
+    
+            for (a0,a1,b01, sub3s) in sub3 :
+                for (a2, b02, b12) in sub3s :
+                    for a3 in xrange(2 * self.index(), 2) :
+                        # obstruction for t[0,3]
+                        B1 = isqrt(a0 * a3)
+                    
+                        for b03 in xrange(-B1, B1 + 1) :
+                            # obstruction for t[1,3]
+                            B3 = isqrt(a1 * a3)
+    
+                            for b13 in xrange(-B3, B3 + 1) :
+                                # obstruction for the minor [0,1,3] of t
+                                if a0*a1*a3 - a0*b13**2 + 2*b01*b13*b03 - b01**2*a3 - a1*b03**2 < 0 :
+                                    continue
+                                
+                                # obstruction for t[2,3]
+                                B3 = isqrt(a2 * a3)
+                                
+                                for b23 in xrange(-B3, B3 + 1) :
+                                    # obstruction for the minor [0,2,3] of t
+                                    if a0*a2*a3 - a0*b23**2 + 2*b02*b23*b03 - b02**2*a3 - a2*b03**2 < 0 :
+                                        continue
+                                    
+                                    # obstruction for the minor [1,2,3] of t
+                                    if a1*a2*a3 - a1*b23**2 + 2*b12*b23*b13 - b12**2*a3 - a2*b13**2 < 0 :
+                                        continue
+    
+                                    t = matrix(ZZ, 4, [a0, b01, b02, b03, b01, a1, b12, b13, b02, b12, a2, b23, b03, b13, b23, a3], check = False)
+                                    if t.det() < 0 :
+                                        continue
+                                    
+                                    t.set_immutable()
+                                    
+                                    yield t
+
+        raise StopIteration
+    
+    def iter_positive_forms(self) :
+        if self.is_reduced() :
+            sub4 = self._calc_iter_reduced_sub4()
+            
+            for (a0, a1, b01, sub4s) in sub4 :
+                t = zero_matrix(ZZ, 4)
+                t[0,0] = a0
+                t[1,1] = a1
+                t[0,1] = b01
+                t[1,0] = b01
+                
+                for (a2, b02, b12, sub4ss) in sub4s :
+                    ts = copy(t)
+                    ts[2,2] = a2
+                    ts[0,2] = b02
+                    ts[2,0] = b02
+                    ts[1,2] = b12
+                    ts[2,1] = b12
+                    
+                    for (a3, b03, b13, b23) in sub4ss :
+                        tss = copy(ts)
+                        tss[3,3] = a3
+                        tss[0,1] = b01
+                        tss[1,0] = b01
+                        tss[0,2] = b02
+                        tss[2,0] = b02
+                        tss[0,3] = b03
+                        tss[3,0] = b03
+                        tss.set_immutable()
+                        
+                        yield tss
+        else :
+            raise NotImplementedError
+
+    def __hash__(self) :
+        return reduce(xor, map(hash, [self.is_reduced(), self.index()]))
+                   
+    def _repr_(self) :
+        return "Diagonal filter (%s)" % self.index()
+    
+    def _latex_(self) :
+        return "Diagonal filter (%s)" % latex(self.index())
+
+def SiegelModularFormG4FourierExpansionRing(K, genus) :
+
+    R = EquivariantMonoidPowerSeriesRing(
+         SiegelModularFormG4Indices_diagonal_lll(genus),
+         TrivialCharacterMonoid("GL(%s,ZZ)" % (genus,), ZZ),
+         TrivialRepresentation("GL(%s,ZZ)" % (genus,), K) )
+
+    return R

--- a/psage/modform/paramodularforms/siegelmodularformgn_fegenerators.py
+++ b/psage/modform/paramodularforms/siegelmodularformgn_fegenerators.py
@@ -1,0 +1,236 @@
+r"""
+Construction of Fourier expansions of Siegel modular forms of arbitrary genus.
+
+AUTHORS:
+
+- Martin Raum (2009 - 05 - 11) Initial version
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from sage.matrix.constructor import diagonal_matrix
+from sage.matrix.constructor import matrix
+from sage.misc.cachefunc import cached_method
+from sage.misc.functional import isqrt
+from sage.misc.misc import prod
+from sage.modules.all import vector
+from sage.modules.free_module import FreeModule
+from sage.quadratic_forms.quadratic_form import QuadraticForm
+from sage.rings.arith import gcd, fundamental_discriminant
+from sage.rings.all import ZZ, Integer, GF
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.structure.sage_object import SageObject
+from psage.modform.paramodularforms.siegelmodularformgn_fourierexpansion import SiegelModularFormGnFourierExpansionRing,\
+    SiegelModularFormGnFilter_diagonal_lll
+import itertools
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_element import EquivariantMonoidPowerSeries_abstract
+
+#===============================================================================
+# DukeImamogulLift
+#===============================================================================
+
+def DukeImamogluLift(f, f_weight, precision) :
+    r"""
+    INPUT:
+    
+    - `f` -- Fourier expansion of a Jacobi form of index `1` and weight ``k + 1 - precision.genus / 2``.
+        
+    NOTE:
+    
+        We follow Kohnen's paper "Lifting modular forms of half-integral weight to Siegel
+        modular forms of even genus", Section 5, Theorem 1. 
+    """
+    if not isinstance(precision, SiegelModularFormGnFilter_diagonal_lll) :
+        raise TypeError, "precision must be an instance of SiegelModularFormGnFilter_diagonal_lll"
+
+    ## TODO: Neatly check the input type.
+    half_integral_weight = not isinstance(f, EquivariantMonoidPowerSeries_abstract)
+    if half_integral_weight :
+        f_k = Integer(f_weight - Integer(1)/2)
+    else :
+        f_k = f_weight
+    
+    fe_ring = SiegelModularFormGnFourierExpansionRing( 
+                            f.parent().base_ring() if half_integral_weight else f.parent().coefficient_domain(),
+                            precision.genus() )
+    
+    form = fe_ring(DukeImamogluLiftFactory().duke_imamoglu_lift( f if half_integral_weight else f.coefficients(),
+                                                                 f_k, precision, half_integral_weight))
+    form._set_precision(precision)
+    
+    return form
+
+
+#===============================================================================
+# DukeImamogluLiftFactory
+#===============================================================================
+
+_duke_imamoglu_lift_factory_cache = None
+
+def DukeImamogluLiftFactory() :
+    global _duke_imamoglu_lift_factory_cache
+    
+    if _duke_imamoglu_lift_factory_cache is None :
+        _duke_imamoglu_lift_factory_cache = DukeImamogluLiftFactory_class()
+        
+    return _duke_imamoglu_lift_factory_cache
+
+#===============================================================================
+# DukeImamogluLiftFactory_class
+#===============================================================================
+
+class DukeImamogluLiftFactory_class (SageObject) :
+    
+    @cached_method
+    def _kohnen_phi(self, a, t) :
+        ## We use a modified power of a, namely for each prime factor p of a
+        ## we use p**floor(v_p(a)/2). This is compensated for in the routine
+        ## of \rho
+        a_modif = 1
+        for (p,e) in a.factor() :
+            a_modif = a_modif * p**(e // 2)
+        
+        res = 0
+        for dsq in filter(lambda d: d.is_square(), a.divisors()) :
+            d = isqrt(dsq)
+            
+            for g_diag in itertools.ifilter( lambda diag: prod(diag) == d,
+                                  itertools.product(*[d.divisors() for _ in xrange(t.nrows())]) ) :
+                for subents in itertools.product(*[xrange(r) for (j,r) in enumerate(g_diag) for _ in xrange(j)]) :
+                    columns = [subents[(j * (j - 1)) // 2:(j * (j + 1)) // 2] for j in xrange(t.nrows())]
+                    g = diagonal_matrix(list(g_diag))
+                    for j in xrange(t.nrows()) :
+                        for i in xrange(j) :
+                            g[i,j] = columns[j][i]
+                         
+                    ginv = g.inverse()   
+                    tg = ginv.transpose() * t * ginv
+                    try :
+                        tg= matrix(ZZ, tg)
+                    except :
+                        continue
+                    if any(tg[i,i] % 2 == 1 for i in xrange(tg.nrows())) :
+                        continue
+                    
+                    tg.set_immutable()
+                        
+                    res = res + self._kohnen_rho(tg, a // dsq)
+        
+        return a_modif * res
+
+    @cached_method
+    def _kohnen_rho(self, t, a) :
+        dt = (-1)**(t.nrows() // 2) * t.det()
+        d = fundamental_discriminant(dt)
+        eps = isqrt(dt // d)
+        
+        res = 1
+        for (p,e) in gcd(a, eps).factor() :
+            pol = self._kohnen_rho_polynomial(t, p).coefficients()
+            if e < len(pol) :
+                res = res * pol[e]
+            
+        return res
+    
+    @cached_method
+    def _kohnen_rho_polynomial(self, t, p) :
+        P = PolynomialRing(ZZ, 'x')
+        x = P.gen(0)
+        
+        #tc = self._minimal_isotropic_subspace_complement_mod_p(t, p)
+        
+        if t[0,0] != 0 :
+            return (1 - x**2)
+        
+        for i in xrange(t.nrows()) :
+            if t[i,i] != 0 :
+                break
+        
+        if i % 2 == 0 :
+            ## Since we have semi definite indices Kohnen's lambda simplifies
+            lambda_p = 1 if t == 0 else -1
+            ## For we multiply x in the second factor by p**(1/2) to make all coefficients rational.
+            return (1 - x**2) * (1 + lambda_p * p**((i + 1) // 2) * x) * \
+                   prod(1 - p**(2*j - 1) * x**2 for j in xrange(1, i // 2))
+        else :
+            return (1 - x**2) * \
+                   prod(1 - p**(2*j - 1) * x**2 for j in xrange(1, i // 2))
+    
+    #===========================================================================
+    # ## TODO: Speadup by implementation in Cython and using enumeration mod p**n and fast
+    # ##       evaluation via shifts
+    # def _minimal_isotropic_subspace_complement_mod_p(self, t, p, cur_form_subspace = None, cur_isotropic_space = None) :
+    #    if not t.base_ring() is GF(p) :
+    #        t = matrix(GF(p), t)
+    #    #q = QuadraticForm(t)
+    #    
+    #    if cur_form_subspace is None :
+    #        cur_form_subspace = FreeModule(GF(p), t.nrows())
+    #    if cur_isotropic_space is None :
+    #        cur_isotropic_space = cur_form_subspace.ambient_module().submodule([])
+    #    
+    #    ## We find a zero length vector. In the orthogonal complement we can then proceed.
+    #    
+    #    for v in cur_form_subspace :
+    #        if v not in cur_isotropic_space \
+    #          and (v * t * v).is_zero() :
+    #            cur_form_subspace = cur_form_subspace.intersection(matrix(GF(p), v * t).right_kernel())
+    #            cur_isotropic_space = cur_isotropic_space + cur_isotropic_space.ambient_module().submodule([v])
+    #            
+    #            return self._minimal_isotropic_subspace_complement_mod_p(t, p, cur_form_subspace, cur_isotropic_space)
+    #    # return complement
+    #    complement_coords =   set(xrange(cur_form_subspace.ambient_module().rank())) \
+    #                        - set(cur_isotropic_space.echelonized_basis_matrix().pivots())
+    #    complement_basis = [ vector(GF(p), [0]*i + [1] + [0]*(cur_form_subspace.ambient_module().rank() - i - 1))
+    #                         for i in complement_coords ]
+    #    
+    #    return matrix(GF(p), [[u * t * v for u in complement_basis] for v in complement_basis])
+    #===========================================================================
+    
+    def duke_imamoglu_lift(self, f, f_k, precision, half_integral_weight = False) :
+        """
+        INPUT:
+        
+        - ``half_integral_weight``   -- If ``False`` we assume that `f` is the Fourier expansion of a
+                                        Jacobi form. Otherwise we assume it is the Fourier expansion
+                                        of a half integral weight elliptic modular form.
+        """
+        
+        if half_integral_weight :
+            coeff_index = lambda d : d
+        else :
+            coeff_index = lambda d : ((d + (-d % 4)) // 4, (-d) % 4)
+        
+        coeffs = dict()
+        
+        for t in precision.iter_positive_forms() :
+            dt = (-1)**(precision.genus() // 2) * t.det()
+            d = fundamental_discriminant(dt)
+            eps = Integer(isqrt(dt / d))
+    
+            coeffs[t] = 0 
+            for a in eps.divisors() :
+                d_a = abs(d * (eps // a)**2)
+                 
+                coeffs[t] = coeffs[t] + a**(f_k - 1) * self._kohnen_phi(a, t) \
+                                        * f[coeff_index(d_a)]
+
+        return coeffs
+    

--- a/psage/modform/paramodularforms/siegelmodularformgn_fourierexpansion.py
+++ b/psage/modform/paramodularforms/siegelmodularformgn_fourierexpansion.py
@@ -1,0 +1,535 @@
+r"""
+Classes describing the Fourier expansion of Siegel modular forms of genus n.
+
+AUTHORS:
+
+- Martin Raum (2009 - 05 - 10) Initial version
+"""
+
+#===============================================================================
+# 
+# Copyright (C) 2010 Martin Raum
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#===============================================================================
+
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_basicmonoids \
+              import TrivialCharacterMonoid, TrivialRepresentation
+from psage.modform.fourier_expansion_framework.monoidpowerseries.monoidpowerseries_ring \
+              import EquivariantMonoidPowerSeriesRing
+from operator import xor
+from sage.matrix.constructor import diagonal_matrix, matrix, zero_matrix, identity_matrix
+from sage.matrix.matrix import is_Matrix
+from sage.misc.flatten import flatten
+from sage.misc.functional import isqrt
+from sage.misc.latex import latex
+from sage.rings.arith import gcd
+from sage.rings.infinity import infinity
+from sage.rings.integer import Integer
+from sage.rings.integer_ring import ZZ
+from sage.rings.rational_field import QQ
+from sage.structure.sage_object import SageObject
+import itertools
+
+#===============================================================================
+# SiegelModularFormGnIndices_diagonal_lll
+#===============================================================================
+
+class SiegelModularFormGnIndices_diagonal_lll ( SageObject ) :
+    r"""
+    All positive definite quadratic forms filtered by their discriminant.
+    """
+    def __init__(self, n, reduced = True) :
+        self.__n = n
+        self.__reduced = reduced
+
+    def ngens(self) :
+        ##FIXME: This is most probably not correct
+        return (self.__n * (self.__n + 1)) // 2 \
+               if self.__reduced else \
+               self.__n**2
+    
+    def gen(self, i = 0) :
+        if i < self.__n :
+            t = diagonal_matrix(ZZ, i * [0] + [2] + (self.__n - i - 1) * [0])
+            t.set_immutable()
+            
+            return t
+        elif i >= self.__n and i < (self.__n * (self.__n + 1)) // 2 :
+            i = i - self.__n
+            
+            for r in xrange(self.__n) :
+                if i >=  self.__n - r - 1 :
+                    i = i - (self.__n - r - 1)
+                    continue
+                
+                c = i + r + 1
+                break
+            
+            t = zero_matrix(ZZ, self.__n)
+            t[r,c] = 1
+            t[c,r] = 1
+            
+            t.set_immutable()
+            return t
+        elif not self.__reduced and i >= (self.__n * (self.__n + 1)) // 2 \
+             and i < self.__n**2 :
+            i = i - (self.__n * (self.__n + 1)) // 2
+            
+            for r in xrange(self.__n) :
+                if i >=  self.__n - r - 1 :
+                    i = i - (self.__n - r - 1)
+                    continue
+                
+                c = i + r + 1
+                break
+            
+            t = zero_matrix(ZZ, self.__n)
+            t[r,c] = -1
+            t[c,r] = -1
+            
+            t.set_immutable()
+            return t
+            
+        raise ValueError, "Generator not defined"
+    
+    def gens(self) :    
+        return [self.gen(i) for i in xrange(self.ngens())]
+
+    def genus(self) :
+        return self.__n
+    
+    def is_commutative(self) :
+        return True
+    
+    def is_reduced(self) :
+        return self.__reduced
+    
+    def monoid(self) :
+        return SiegelModularFormGnIndices_diagonal_lll(self.__n, False) 
+
+    def group(self) :
+        return "GL(%s,ZZ)" % (self.__n,)
+        
+    def is_monoid_action(self) :
+        """
+        ``True`` if the representation respects the monoid structure.
+        """
+        return True
+    
+    def filter(self, bound) :
+        return SiegelModularFormGnFilter_diagonal_lll(self.__n, bound, self.__reduced)
+        
+    def filter_all(self) :
+        return SiegelModularFormGnFilter_diagonal_lll(self.__n, infinity, self.__reduced)
+    
+    def minimal_composition_filter(self, ls, rs) :
+        if len(ls) == 0 or len(rs) == 0 :
+            return SiegelModularFormGnFilter_diagonal_lll(self.__n, 0, self.__reduced)
+
+        maxd = flatten( map(lambda (ml, mr): [ml[i,i] + mr[i,i] for i in xrange(self.__n)],
+                                itertools.product(ls, rs) ) )
+
+        return SiegelModularFormGnFilter_diagonal_lll(self.__n, maxd + 1, self.__reduced)
+  
+    def _gln_lift(self, v, position = 0) :
+        """
+        Create a unimodular matrix which contains v as a row or column.
+        
+        INPUT:
+        
+        - `v`           -- A primitive vector over `\ZZ`.
+        - ``position``  -- (Integer, default: 0) Determines the position of `v` in the result.
+                           - `0` -- left column
+                           - `1` -- right column
+                           - `2` -- upper row
+                           - `3` -- bottom row
+        """
+        
+        n = len(v)
+        u = identity_matrix(n)
+        if n == 1 :
+            return u
+        
+        for i in xrange(n) :
+            if v[i] < 0 :
+                v[i] = -v[i]
+                u[i,i] = -1
+        
+        while True :
+            (i, e) = min(enumerate(v), key = lambda e: e[1])
+            
+            if e == 0 :
+                cur_last_entry = n - 1
+                for j in xrange(n - 1, -1, -1) :
+                    if v[j] == 0 :
+                        if cur_last_entry != j :
+                            us = identity_matrix(n)
+                            us[cur_last_entry,cur_last_entry] = 0
+                            us[j,j] = 0
+                            us[cur_last_entry,j] = 1
+                            us[j,cur_last_entry] = 1
+                            u = us * u
+                            
+                            v[j] = v[cur_last_entry]
+                            v[cur_last_entry] = 0
+
+                        cur_last_entry = cur_last_entry - 1
+            
+                
+                us = identity_matrix(n,n) 
+                us.set_block(0, 0, self._gln_lift(v[:cur_last_entry + 1]))
+                
+                
+                u = u.inverse() * us
+                u = matrix(ZZ, u)
+                
+                if position == 1 or position == 3 :
+                    us = identity_matrix(n)
+                    us[0,0] = 0
+                    us[n-1,n-1] = 0
+                    us[0,n-1] = 1
+                    us[n-1,0] = 1
+                    
+                    u = u * us
+                    
+                if position == 0 or position == 1 :
+                    return u
+                elif position == 2 or position == 3 :
+                    return u.transpose()
+                else :
+                    raise ValueError("Unknown position")
+            
+            if i != 0 :
+                us = identity_matrix(n)
+                us[0,0] = 0
+                us[i,i] = 0
+                us[0,i] = 1
+                us[i,0] = 1
+                u = us * u
+                
+                v[i] = v[0]
+                v[0] = e
+
+            for j in xrange(1,n) :
+                h = - (v[j] // e)
+                us = identity_matrix(n)
+                us[j,0] = h
+                u = us * u
+                
+                v[j] = v[j] + h*v[0]
+  
+    def _check_definiteness(self, t) :
+        """
+        OUTPUT:
+        
+            An integer. `1` if `t` is positive definite, `0` if it is semi definite and `-1` in all other cases.
+            
+        NOTE:
+        
+            We have to use this implementations since the quadratic forms' implementation has a bug. 
+        """
+        ## We compute the rational diagonal form and whenever there is an indefinite upper
+        ## left submatrix we abort.
+        t = matrix(QQ, t)
+        n = t.nrows()
+        
+        indefinite = False
+        
+        for i in xrange(n) :
+            if t[i,i] < 0 :
+                return -1
+            elif t[i,i] == 0 :
+                indefinite = True
+                for j in xrange(i + 1, n) :
+                    if t[i,j] != 0 :
+                        return -1
+            else :
+                for j in xrange(i + 1, n) :
+                    t.add_multiple_of_row(j, i, -t[j,i]/t[i,i])
+                    t.add_multiple_of_column(j, i, -t[i,j]/t[i,i])
+                
+        return 0 if indefinite else 1
+        
+    def _reduction_function(self) :
+        return self.reduce
+    
+    def reduce(self, t) :
+        ## We compute the rational diagonal form of t. Whenever a zero entry occures we
+        ## find a primitive isotropic vector and apply a base change, such that t finally
+        ## has the form diag(0,0,...,P) where P is positive definite. P will then be a
+        ## LLL reduced.
+        
+        ot = t
+        t = matrix(QQ, t)
+        n = t.nrows()
+        u = identity_matrix(QQ, n)
+        
+        for i in xrange(n) :
+            if t[i,i] < 0 :
+                return None
+            elif t[i,i] == 0 :
+                ## get the isotropic vector
+                v = u.column(i)
+                v = v.denominator() * v
+                v = v / gcd(list(v))
+                u = self._gln_lift(v, 0)
+                
+                t = u.transpose() * ot * u
+                ts = self.reduce(t.submatrix(1,1,n-1,n-1))
+                if ts is None :
+                    return None
+                t.set_block(1, 1, ts[0])
+                
+                t.set_immutable()
+                
+                return (t,1)
+            else :
+                for j in xrange(i + 1, n) :
+                    us = identity_matrix(QQ, n, n)
+                    us[i,j] = -t[i,j]/t[i,i]
+                    u = u * us
+                     
+                    t.add_multiple_of_row(j, i, -t[j,i]/t[i,i])
+                    t.add_multiple_of_column(j, i, -t[i,j]/t[i,i])
+        
+        u = ot.LLL_gram()
+        t = u.transpose() * ot * u
+        t.set_immutable()
+        
+        return (t, 1)
+
+    def decompositions(self, t) :
+        for diag in itertools.product(*[xrange(t[i,i] + 1) for i in xrange(self.__n)]) :
+            for subents in  itertools.product( *[ xrange(-2 * isqrt(diag[i] * diag[j]), 2 * isqrt(diag[i] * diag[j]) + 1)
+                                                  for i in xrange(self.__n - 1) 
+                                                  for j in xrange(i + 1, self.__n) ] ) :
+                t1 = matrix(ZZ, [[ 2 * diag[i]
+                                   if i == j else
+                                      (subents[self.__n * i - (i * (i + 1)) // 2 + j - i - 1]
+                                       if i < j else
+                                       subents[self.__n * j - (j * (j + 1)) // 2 + i - j - 1])
+                                  for i in xrange(self.__n) ]
+                                 for j in xrange(self.__n) ] )
+ 
+                if self._check_definiteness(t1) == -1 :
+                    continue
+ 
+                t2 = t - t1
+                if self._check_definiteness(t2) == -1 :
+                    continue
+                
+                t1.set_immutable()
+                t2.set_immutable()
+                
+                yield (t1, t2)
+
+        raise StopIteration
+    
+    def zero_element(self) :
+        t = zero_matrix(ZZ, self.__n)
+        t.set_immutable()
+        return t
+
+    def __contains__(self, x) :
+        return is_Matrix(x) and x.base_ring() is ZZ and x.nrows() == self.__n and x.ncols() == self.__n
+        
+    def __cmp__(self, other) :
+        c = cmp(type(self), type(other))
+        if c == 0 :
+            c = cmp(self.__reduced, other.__reduced)
+        if c == 0 :
+            c = cmp(self.__n, other.__n)
+            
+        return c
+    
+    def __hash__(self) :
+        return xor(hash(self.__reduced), hash(self.__n))
+    
+    def _repr_(self) :
+        if self.__reduced :
+            return "Reduced quadratic forms of rank %s over ZZ" % (self.__n,)
+        else :
+            return "Quadratic forms over of rank %s ZZ" % (self.__n,)
+            
+    def _latex_(self) :
+        if self.__reduced :
+            return "Reduced quadratic forms of rank %s over ZZ" % (latex(self.__n),)
+        else :
+            return "Quadratic forms over of rank %s ZZ" % (latex(self.__n),)
+
+#===============================================================================
+# SiegelModularFormGnFilter_diagonal_lll
+#===============================================================================
+
+class SiegelModularFormGnFilter_diagonal_lll ( SageObject ) :
+    def __init__(self, n, bound, reduced = True) :
+        if isinstance(bound, SiegelModularFormGnFilter_diagonal_lll) :
+            bound = bound.index()
+
+        self.__n = n
+        self.__bound = bound
+        self.__reduced = reduced
+        
+        self.__ambient = SiegelModularFormGnIndices_diagonal_lll(n, reduced)
+
+    def filter_all(self) :
+        return SiegelModularFormGnFilter_diagonal_lll(self.__n, infinity, self.__reduced)
+    
+    def zero_filter(self) :
+        return SiegelModularFormGnFilter_diagonal_lll(self.__n, 0, self.__reduced) 
+
+    def is_infinite(self) :
+        return self.__bound is infinity
+    
+    def is_all(self) :
+        return self.is_infinite()
+
+    def genus(self) :
+        return self.__n
+
+    def index(self) :
+        return self.__bound
+
+    def is_reduced(self) :
+        return self.__reduced
+    
+    def __contains__(self, t) :
+        if self.__bound is infinity :
+            return True
+
+        for i in xrange(self.__n) :
+            if t[i,i] >= 2 * self.__bound :
+                return False
+            
+        return True
+    
+    def __iter__(self) :
+        if self.__bound is infinity :
+            raise ValueError, "infinity is not a true filter index"
+
+        if self.__reduced :
+            ##TODO: This is really primitive. We barely reduce arbitrary forms.
+            for diag in itertools.product(*[xrange(self.__bound) for _ in xrange(self.__n)]) :
+                for subents in  itertools.product( *[ xrange(-2 * isqrt(diag[i] * diag[j]), 2 * isqrt(diag[i] * diag[j]) + 1)
+                                                      for i in xrange(self.__n - 1) 
+                                                      for j in xrange(i + 1, self.__n) ] ) :
+                    t = matrix(ZZ, [[ 2 * diag[i]
+                                      if i == j else
+                                      (subents[self.__n * i - (i * (i + 1)) // 2 + j - i - 1]
+                                       if i < j else
+                                       subents[self.__n * j - (j * (j + 1)) // 2 + i - j - 1])
+                                     for i in xrange(self.__n) ]
+                                    for j in xrange(self.__n) ] )
+
+                    t = self.__ambient.reduce(t)
+                    if t is None : continue
+                    t = t[0]
+                    
+                    t.set_immutable()
+                    
+                    yield t
+        else :
+            for diag in itertools.product(*[xrange(self.__bound) for _ in xrange(self.__n)]) :
+                for subents in  itertools.product( *[ xrange(-2 * isqrt(diag[i] * diag[j]), 2 * isqrt(diag[i] * diag[j]) + 1)
+                                                      for i in xrange(self.__n - 1) 
+                                                      for j in xrange(i + 1, self.__n) ] ) :
+                    t = matrix(ZZ, [[ 2 * diag[i]
+                                      if i == j else
+                                      (subents[self.__n * i - (i * (i + 1)) // 2 + j - i - 1]
+                                       if i < j else
+                                       subents[self.__n * j - (j * (j + 1)) // 2 + i - j - 1])
+                                     for i in xrange(self.__n) ]
+                                    for j in xrange(self.__n) ] )
+                    if self._check_definiteness(t) == -1 :
+                        continue
+                    
+                    t.set_immutable()
+                    
+                    yield t
+
+        raise StopIteration
+    
+    def iter_positive_forms(self) :
+        if self.__reduced :
+            ##TODO: This is really primitive. We barely reduce arbitrary forms.
+            for diag in itertools.product(*[xrange(self.__bound) for _ in xrange(self.__n)]) :
+                for subents in  itertools.product( *[ xrange(-2 * isqrt(diag[i] * diag[j]), 2 * isqrt(diag[i] * diag[j]) + 1)
+                                                      for i in xrange(self.__n - 1) 
+                                                      for j in xrange(i + 1, self.__n) ] ) :
+                    t = matrix(ZZ, [[ 2 * diag[i]
+                                      if i == j else
+                                      (subents[self.__n * i - (i * (i + 1)) // 2 + j - i - 1]
+                                       if i < j else
+                                       subents[self.__n * j - (j * (j + 1)) // 2 + i - j - 1])
+                                     for i in xrange(self.__n) ]
+                                    for j in xrange(self.__n) ] )
+    
+                    t = self.__ambient.reduce(t)
+                    if t is None : continue
+                    t = t[0]
+                    if t[0,0] == 0 : continue
+                    
+                    t.set_immutable()
+                    
+                    yield t
+        else :
+            for diag in itertools.product(*[xrange(self.__bound) for _ in xrange(self.__n)]) :
+                for subents in  itertools.product( *[ xrange(-2 * isqrt(diag[i] * diag[j]), 2 * isqrt(diag[i] * diag[j]) + 1)
+                                                      for i in xrange(self.__n - 1) 
+                                                      for j in xrange(i + 1, self.__n) ] ) :
+                    t = matrix(ZZ, [[ 2 * diag[i]
+                                      if i == j else
+                                      (subents[self.__n * i - (i * (i + 1)) // 2 + j - i - 1]
+                                       if i < j else
+                                       subents[self.__n * j - (j * (j + 1)) // 2 + i - j - 1])
+                                     for i in xrange(self.__n) ]
+                                    for j in xrange(self.__n) ] )
+    
+                    if self.__ambient._check_definiteness(t) != 1 :
+                        continue
+                    
+                    t.set_immutable()
+                    
+                    yield t
+    
+    def __cmp__(self, other) :
+        c = cmp(type(self), type(other))
+        if c == 0 :
+            c = cmp(self.__reduced, other.__reduced)
+        if c == 0 :
+            c = cmp(self.__n, other.__n)
+        if c == 0 :
+            c = cmp(self.__bound, other.__bound)
+            
+        return c
+
+    def __hash__(self) :
+        return reduce(xor, map(hash, [type(self), self.__reduced, self.__bound]))
+                   
+    def _repr_(self) :
+        return "Diagonal filter (%s)" % self.__bound
+    
+    def _latex_(self) :
+        return "Diagonal filter (%s)" % latex(self.__bound)
+
+def SiegelModularFormGnFourierExpansionRing(K, genus) :
+
+    R = EquivariantMonoidPowerSeriesRing(
+         SiegelModularFormGnIndices_diagonal_lll(genus),
+         TrivialCharacterMonoid("GL(%s,ZZ)" % (genus,), ZZ),
+         TrivialRepresentation("GL(%s,ZZ)" % (genus,), K) )
+
+    return R

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,18 @@ ext_modules = [
 
     Extension("psage.modform.jacobiforms.jacobiformd1nn_fourierexpansion_cython",
               ["psage/modform/jacobiforms/jacobiformd1nn_fourierexpansion_cython.pyx"]),
+    
+    Extension("psage.modform.paramodularforms.siegelmodularformg2_misc_cython",
+              ["psage/modform/paramodularforms/siegelmodularformg2_misc_cython.pyx"]),
+
+    Extension("psage.modform.paramodularforms.siegelmodularformg2_fourierexpansion_cython",
+              ["psage/modform/paramodularforms/siegelmodularformg2_fourierexpansion_cython.pyx"]),
+
+    Extension("psage.modform.paramodularforms.siegelmodularformg2vv_fegenerators_cython",
+              ["psage/modform/paramodularforms/siegelmodularformg2vv_fegenerators_cython.pyx"]),
+
+    Extension("psage.modform.paramodularforms.paramodularformd2_fourierexpansion_cython",
+              ["psage/modform/paramodularforms/paramodularformd2_fourierexpansion_cython.pyx"]),
 
     Extension("psage.modform.siegel.fastmult",
               ["psage/modform/siegel/fastmult.pyx"]),


### PR DESCRIPTION
1) Update all documentation and Latex string in the Fourier expansion framework.
2) Integrate Siegel and paramodular forms.
3) Split the construction functors for monoidpowerseries_ring and _module.
   This change is neseccary since the category framework in Sage 4.8 enforces the codomains of functors.

I have squashed all the commits which result from patches I extracted from my old, private git clone of PSage.
